### PR TITLE
New github release workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,4 @@
-name: .NET
+name: Build
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build
       run: |
         $ver = '${{ github.ref_name }}'
-        dotnet build --no-restore -c Release --nologo -p:Version=$ver -p:FileVersion=$ver -p:AssemblyVersion=$ver'
+        invoke-expression 'dotnet build --no-restore --configuration Release --nologo -p:Version=$ver -p:FileVersion=$ver -p:AssemblyVersion=$ver'
     - name: Write version into manifest
       run: |
         $ver = '${{ github.ref_name }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,77 +1,86 @@
-name: Release
-
 on:
+  workflow_dispatch:
+    inputs: {}
   push:
     tags:
+      - '*'
+
+name: Release
 
 jobs:
-  build:
-
+  release:
+    name: Release
     runs-on: windows-latest
-
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '7.x.x'
-    - name: Download Dalamud
-      run: |
-        Invoke-WebRequest -Uri https://goatcorp.github.io/dalamud-distrib/stg/latest.zip -OutFile latest.zip
-        Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\dev\"
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: |
-        $ver = '${{ github.ref_name }}'
-        invoke-expression 'dotnet build --no-restore --configuration Release --nologo -p:Version=$ver -p:FileVersion=$ver -p:AssemblyVersion=$ver'
-    - name: Write version into manifest
-      run: |
-        $ver = '${{ github.ref_name }}'
-        $path = './RoleplayingVoiceDalamud/bin/Release/net7.0/RoleplayingVoiceDalamud.json'
-        $json = Get-Content -Raw $path | ConvertFrom-Json
-        $json.AssemblyVersion = $ver
-        $content = $json | ConvertTo-Json
-       set-content -Path $path -Value $content
-    - name: Packing Release
-      run: |
-        pushd publish_gtk
-        7z a ../RoleplayingVoiceDalamud/bin/Release/net7.0/RoleplayingVoiceDalamud.zip publish
-        popd
-      shell: bash
-    - name: Pushing Release
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '7.x.x'
+
+      - name: Download Dalamud
+        run: |
+          Invoke-WebRequest -Uri https://goatcorp.github.io/dalamud-distrib/stg/latest.zip -OutFile latest.zip
+          Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\dev\"
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: |
+          $ver = '${{ github.ref }}' -replace 'refs/tags/',''
+          dotnet build --no-restore -c Release --nologo -p:Version=$ver
+
+      - name: Write version into manifest
+        run: |
+          $ver = '${{ github.ref }}' -replace 'refs/tags/',''
+          $path = './RoleplayingVoiceDalamud/bin/Release/net7.0/RoleplayingVoiceDalamud.json'
+          $content = get-content -path $path
+          $content = $content -replace '0.0.0.0',$ver
+          set-content -Path $path -Value $content
+
+      - name: Packing Release
+        run: |
+          pushd RoleplayingVoiceDalamud/bin/Release/net7.0
+          7z a ../RoleplayingVoiceDalamud.zip *
+          popd
+        shell: bash
+
+      - name: Create Release
         uses: ncipollo/release-action@v1.12.0
         with:
-          name: RoleplayingVoiceDalamud-${{ github.ref_name }}
-          artifacts: "./RoleplayingVoiceDalamud/bin/Release/net7.0/*.zip"
+          name: RoleplayingVoiceDalamud ${{ github.ref_name }}
+          artifacts: "./RoleplayingVoiceDalamud/bin/Release/*.zip"
           tag: ${{ github.ref_name }}
-          #body: "Are you lost? This is no place to be in."
+          body: "Are you lost? This is no place to be in."
           omitBodyDuringUpdate: true
           allowUpdates: true
           replacesArtifacts: true
-          #token: ${{ secrets.RELEASE_TOKEN }}
-    - name: Write out repo.json
-      run: |
-        $ver = '${{ github.ref_name }}'
-        $path = './repo.json'
-        $json = Get-Content -Raw $path | ConvertFrom-Json
-        $json[0].AssemblyVersion = $ver
-        $json[0].TestingAssemblyVersion = $ver
-        $json[0].DownloadLinkInstall = $json.DownloadLinkInstall -replace '[^/]+/RoleplayingVoiceDalamud.zip',"$ver/RoleplayingVoiceDalamud.zip"
-        $json[0].DownloadLinkTesting = $json.DownloadLinkTesting -replace '[^/]+/RoleplayingVoiceDalamud.zip',"$ver/RoleplayingVoiceDalamud.zip"
-        $json[0].DownloadLinkUpdate = $json.DownloadLinkUpdate -replace '[^/]+/RoleplayingVoiceDalamud.zip',"$ver/RoleplayingVoiceDalamud.zip"
-        $content = $json | ConvertTo-Json -AsArray
-        set-content -Path $path -Value $content
+          token: ${{ secrets.RELEASE }}
 
-    - name: Commit repo.json
-      run: |
-        git config --global user.name "Actions User"
-        git config --global user.email "actions@github.com"
-        git fetch origin master
-        git branch -f master ${{ github.sha }}
-        git checkout master
-        git add repo.json
-        git commit -m "[CI] Updating repo.json for ${{ github.ref_name }}" || true
-        git push origin master
+      - name: Write out repo.json
+        run: |
+          $ver = '${{ github.ref_name }}'
+          $path = './repo.json'
+          $json = Get-Content -Raw $path | ConvertFrom-Json
+          $json[0].AssemblyVersion = $ver
+          $json[0].TestingAssemblyVersion = $ver
+          $json[0].DownloadLinkInstall = $json.DownloadLinkInstall -replace '[^/]+/RoleplayingVoiceDalamud.zip',"$ver/RoleplayingVoiceDalamud.zip"
+          $json[0].DownloadLinkTesting = $json.DownloadLinkTesting -replace '[^/]+/RoleplayingVoiceDalamud.zip',"$ver/RoleplayingVoiceDalamud.zip"
+          $json[0].DownloadLinkUpdate = $json.DownloadLinkUpdate -replace '[^/]+/RoleplayingVoiceDalamud.zip',"$ver/RoleplayingVoiceDalamud.zip"
+          $content = $json | ConvertTo-Json -AsArray
+          set-content -Path $path -Value $content
+
+      - name: Commit repo.json
+        run: |
+          git config --global user.name "Actions User"
+          git config --global user.email "actions@github.com"
+          git fetch origin master
+          git branch -f master ${{ github.sha }}
+          git checkout master
+          git add repo.json
+          git commit -m "[CI] Updating repo.json for ${{ github.ref_name }}" || true
+          git push origin master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  push:
+    tags:
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '7.x.x'
+    - name: Download Dalamud
+      run: |
+        Invoke-WebRequest -Uri https://goatcorp.github.io/dalamud-distrib/stg/latest.zip -OutFile latest.zip
+        Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\dev\"
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: |
+        $ver = '${{ github.ref_name }}'
+        dotnet build --no-restore -c Release --nologo -p:Version=$ver -p:FileVersion=$ver -p:AssemblyVersion=$ver'
+    - name: Write version into manifest
+      run: |
+        $ver = '${{ github.ref_name }}'
+        $path = './RoleplayingVoiceDalamud/bin/Release/net7.0/RoleplayingVoiceDalamud.json'
+        $json = Get-Content -Raw $path | ConvertFrom-Json
+        $json.AssemblyVersion = $ver
+        $content = $json | ConvertTo-Json
+       set-content -Path $path -Value $content
+    - name: Packing Release
+      run: |
+        pushd publish_gtk
+        7z a ../RoleplayingVoiceDalamud/bin/Release/net7.0/RoleplayingVoiceDalamud.zip publish
+        popd
+      shell: bash
+    - name: Pushing Release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          name: RoleplayingVoiceDalamud-${{ github.ref_name }}
+          artifacts: "./RoleplayingVoiceDalamud/bin/Release/net7.0/*.zip"
+          tag: ${{ github.ref_name }}
+          #body: "Are you lost? This is no place to be in."
+          omitBodyDuringUpdate: true
+          allowUpdates: true
+          replacesArtifacts: true
+          #token: ${{ secrets.RELEASE_TOKEN }}
+    - name: Write out repo.json
+      run: |
+        $ver = '${{ github.ref_name }}'
+        $path = './repo.json'
+        $json = Get-Content -Raw $path | ConvertFrom-Json
+        $json[0].AssemblyVersion = $ver
+        $json[0].TestingAssemblyVersion = $ver
+        $json[0].DownloadLinkInstall = $json.DownloadLinkInstall -replace '[^/]+/RoleplayingVoiceDalamud.zip',"$ver/RoleplayingVoiceDalamud.zip"
+        $json[0].DownloadLinkTesting = $json.DownloadLinkTesting -replace '[^/]+/RoleplayingVoiceDalamud.zip',"$ver/RoleplayingVoiceDalamud.zip"
+        $json[0].DownloadLinkUpdate = $json.DownloadLinkUpdate -replace '[^/]+/RoleplayingVoiceDalamud.zip',"$ver/RoleplayingVoiceDalamud.zip"
+        $content = $json | ConvertTo-Json -AsArray
+        set-content -Path $path -Value $content
+
+    - name: Commit repo.json
+      run: |
+        git config --global user.name "Actions User"
+        git config --global user.email "actions@github.com"
+        git fetch origin master
+        git branch -f master ${{ github.sha }}
+        git checkout master
+        git add repo.json
+        git commit -m "[CI] Updating repo.json for ${{ github.ref_name }}" || true
+        git push origin master

--- a/RoleplayingVoiceDalamud/DalamudPackager.targets
+++ b/RoleplayingVoiceDalamud/DalamudPackager.targets
@@ -13,6 +13,6 @@
 			ProjectDir="$(ProjectDir)"
 			OutputPath="$(OutputPath)"
 			AssemblyName="$(AssemblyName)"
-			MakeZip="true"/>
+			MakeZip="false"/>
 	</Target>
 </Project>

--- a/RoleplayingVoiceDalamud/RoleplayingVoiceDalamud.csproj
+++ b/RoleplayingVoiceDalamud/RoleplayingVoiceDalamud.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net7.0</TargetFramework>
 		<LangVersion>9.0</LangVersion>
-		<Version>0.0.0.7</Version>
+		<Version>0.0.0.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
This will allows new releases to be made by just pushing a new tag, HOWEVER there's 2 things that need to be setup.
The repo needs a secret called RELEASE, this name can be changed in release.yml@62 `token: ${{ secrets.RELEASE }}`.
And in repo settings -> actions -> general -> `Workflow permissions` to read and write.
As an extra, if the master branch is protected, especially with `Require x before merging` chances are the new release won't actually be pushed to people.