### PR TITLE
Add Tabs and Moveable cache location

### DIFF
--- a/RoleplayingVoiceDalamud/Configuration.cs
+++ b/RoleplayingVoiceDalamud/Configuration.cs
@@ -3,6 +3,7 @@ using Dalamud.Plugin;
 using RoleplayingVoiceCore.AudioRecycler;
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace RoleplayingVoice {
     public class Configuration : IPluginConfiguration {
@@ -12,6 +13,7 @@ namespace RoleplayingVoice {
         private float _otherCharacterVolume = 1;
         private float _unfocusedCharacterVolume = 0.5f;
         bool useAggressiveCaching = true;
+        private string cacheFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "RPVoiceCache");
         int IPluginConfiguration.Version { get; set; }
 
         #region Saved configuration values
@@ -26,6 +28,7 @@ namespace RoleplayingVoice {
         public float OtherCharacterVolume { get => _otherCharacterVolume; set => _otherCharacterVolume = value; }
         public float UnfocusedCharacterVolume { get => _unfocusedCharacterVolume; set => _unfocusedCharacterVolume = value; }
         public bool UseAggressiveSplicing { get => useAggressiveCaching; set => useAggressiveCaching = value; }
+        public string CacheFolder { get => cacheFolder; set => cacheFolder = value; }
         #endregion
 
         private readonly DalamudPluginInterface pluginInterface;

--- a/RoleplayingVoiceDalamud/Plugin.cs
+++ b/RoleplayingVoiceDalamud/Plugin.cs
@@ -4,7 +4,6 @@ using Dalamud.Game.Gui;
 using Dalamud.Interface.Windowing;
 using Dalamud.Plugin;
 using FFXIVLooseTextureCompiler.Networking;
-using Lumina.Excel.GeneratedSheets;
 using RoleplayingVoice.Attributes;
 using RoleplayingVoiceCore;
 using System;
@@ -180,7 +179,7 @@ namespace RoleplayingVoice {
             }
         }
         public void InitialzeManager() {
-            _roleplayingVoiceManager = new RoleplayingVoiceManager(config.ApiKey, _networkedClient, config.CharacterVoices);
+            _roleplayingVoiceManager = new RoleplayingVoiceManager(config.ApiKey, config.CacheFolder, _networkedClient, config.CharacterVoices);
             _roleplayingVoiceManager.VoicesUpdated += _roleplayingVoiceManager_VoicesUpdated;
             window.Manager = _roleplayingVoiceManager;
         }

--- a/RoleplayingVoiceDalamud/Plugin.cs
+++ b/RoleplayingVoiceDalamud/Plugin.cs
@@ -168,8 +168,7 @@ namespace RoleplayingVoice {
         private void Config_OnConfigurationChanged(object sender, EventArgs e) {
             if (config != null) {
                 if (_roleplayingVoiceManager == null ||
-                    _roleplayingVoiceManager.ApiKey != config.ApiKey
-                    && config.ApiKey.All(c => char.IsAsciiLetterOrDigit(c))
+                    config.ApiKey.All(c => char.IsAsciiLetterOrDigit(c))
                     && !string.IsNullOrEmpty(config.ApiKey)) {
                     InitialzeManager();
                 }

--- a/RoleplayingVoiceDalamud/PluginWindow.cs
+++ b/RoleplayingVoiceDalamud/PluginWindow.cs
@@ -8,9 +8,10 @@ using System.Linq;
 using System.Net;
 using System.Numerics;
 using System.Threading.Tasks;
-
-namespace RoleplayingVoice {
-    public class PluginWindow : Window {
+namespace RoleplayingVoice
+{
+    public class PluginWindow : Window
+    {
         private Configuration configuration;
         RoleplayingVoiceManager _manager = null;
         BetterComboBox voiceComboBox;
@@ -41,7 +42,8 @@ namespace RoleplayingVoice {
 
         public event EventHandler RequestingReconnect;
 
-        public PluginWindow() : base("Roleplaying Voice Config") {
+        public PluginWindow() : base("Roleplaying Voice Config")
+        {
             IsOpen = true;
             Size = new Vector2(295, 550);
             initialSize = Size;
@@ -52,17 +54,22 @@ namespace RoleplayingVoice {
             voiceComboBox.SelectedIndex = 0;
         }
 
-        private void VoiceComboBox_OnSelectedIndexChanged(object sender, EventArgs e) {
-            if (voiceComboBox != null && _voiceList != null) {
+        private void VoiceComboBox_OnSelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (voiceComboBox != null && _voiceList != null)
+            {
                 characterVoice = _voiceList[voiceComboBox.SelectedIndex];
             }
         }
 
-        public Configuration Configuration {
+        public Configuration Configuration
+        {
             get => configuration;
-            set {
+            set
+            {
                 configuration = value;
-                if (configuration != null) {
+                if (configuration != null)
+                {
                     serverIP = configuration.ConnectionIP != null ? configuration.ConnectionIP.ToString() : "";
                     apiKey = configuration.ApiKey != null &&
                     configuration.ApiKey.All(c => char.IsAsciiLetterOrDigit(c)) ? configuration.ApiKey : "";
@@ -76,10 +83,13 @@ namespace RoleplayingVoice {
         }
 
         public DalamudPluginInterface PluginInterface { get; internal set; }
-        public RoleplayingVoiceManager Manager {
-            get => _manager; set {
+        public RoleplayingVoiceManager Manager
+        {
+            get => _manager; set
+            {
                 _manager = value;
-                if (_manager != null) {
+                if (_manager != null)
+                {
                     managerNullMessage = string.Empty;
                     managerNull = false;
                     _manager.OnApiValidationComplete += _manager_OnApiValidationComplete;
@@ -87,9 +97,11 @@ namespace RoleplayingVoice {
             }
         }
 
-        internal ClientState ClientState {
+        internal ClientState ClientState
+        {
             get => clientState;
-            set {
+            set
+            {
                 clientState = value;
                 clientState.Login += ClientState_Login;
                 clientState.Logout += ClientState_Logout;
@@ -98,27 +110,61 @@ namespace RoleplayingVoice {
 
         public Plugin PluginReference { get; internal set; }
 
-        private void ClientState_Logout(object sender, EventArgs e) {
+        private void ClientState_Logout(object sender, EventArgs e)
+        {
             characterVoice = "None";
             _loggedIn = false;
         }
 
-        private void ClientState_Login(object sender, EventArgs e) {
-            if (configuration.Characters != null) {
-                if (configuration.Characters.ContainsKey(clientState.LocalPlayer.Name.TextValue)) {
+        private void ClientState_Login(object sender, EventArgs e)
+        {
+            if (configuration.Characters != null)
+            {
+                if (configuration.Characters.ContainsKey(clientState.LocalPlayer.Name.TextValue))
+                {
                     characterVoice = configuration.Characters[clientState.LocalPlayer.Name.TextValue]
                         != null ? configuration.Characters[clientState.LocalPlayer.Name.TextValue] : "";
-                } else {
+                }
+                else
+                {
                     characterVoice = "None";
                 }
-            } else {
+            }
+            else
+            {
                 characterVoice = "None";
             }
             _loggedIn = true;
             RefreshVoices();
         }
-        public override void Draw() {
-            ImGui.Text("Server IP");
+        public override void Draw()
+        {
+            //// UI REWORK
+
+            if (ImGui.BeginTabBar("ConfigTabs"))
+            {
+                if (ImGui.BeginTabItem("General"))
+                {
+                    DrawGeneral();
+                    ImGui.EndTabItem();
+                }
+
+                if (ImGui.BeginTabItem("Volume"))
+                {
+                    DrawVolume();
+                    ImGui.EndTabItem();
+                }
+
+                if (ImGui.BeginTabItem("Server"))
+                {
+                    DrawServer();
+                    ImGui.EndTabItem();
+                }
+                ImGui.EndTabBar();
+            }
+
+            ////
+            /*ImGui.Text("Server IP");
             ImGui.SetNextItemWidth(ImGui.GetContentRegionMax().X);
             ImGui.InputText("##serverIP", ref serverIP, 2000);
 
@@ -176,26 +222,34 @@ namespace RoleplayingVoice {
             if (ImGui.Button("Reconnect")) {
                 RequestingReconnect?.Invoke(this, EventArgs.Empty);
             }
+            */
             var originPos = ImGui.GetCursorPos();
             // Place save button in bottom left + some padding / extra space
             ImGui.SetCursorPosX(ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMax().X + 10f);
             ImGui.SetCursorPosY(ImGui.GetWindowContentRegionMax().Y - ImGui.GetFrameHeight() - 10f);
-            if (ImGui.Button("Save")) {
-                if (InputValidation()) {
-                    if (configuration != null && !string.IsNullOrEmpty(apiKey)) {
+            if (ImGui.Button("Save"))
+            {
+                if (InputValidation())
+                {
+                    if (configuration != null && !string.IsNullOrEmpty(apiKey))
+                    {
                         apiKeyValidated = false;
                         save = true;
-                        if (_manager == null) {
+                        if (_manager == null)
+                        {
                             managerNullMessage = "Somehow, the manager went missing. Contact a developer!";
                             managerNull = true;
                             PluginReference.InitialzeManager();
                         }
-                        if (_manager != null) {
+                        if (_manager != null)
+                        {
                             managerNullMessage = string.Empty;
                             managerNull = false;
                             Task.Run(() => _manager.ApiValidation(apiKey));
                         }
-                    } else if (string.IsNullOrEmpty(apiKey)) {
+                    }
+                    else if (string.IsNullOrEmpty(apiKey))
+                    {
                         isapiKeyValid = false;
                         apiKeyErrorMessage = "API Key is empty! Please check the input.";
                     }
@@ -208,18 +262,23 @@ namespace RoleplayingVoice {
             // Place close button in bottom right + some padding / extra space
             ImGui.SetCursorPosX(ImGui.GetWindowContentRegionMax().X - ImGui.CalcTextSize("Close").X - 20f);
             ImGui.SetCursorPosY(ImGui.GetWindowContentRegionMax().Y - ImGui.GetFrameHeight() - 10f);
-            if (ImGui.Button("Close")) {
+            if (ImGui.Button("Close"))
+            {
                 // Because we don't trust the user
-                if (InputValidation()) {
-                    if (configuration != null && !string.IsNullOrEmpty(apiKey)) {
+                if (InputValidation())
+                {
+                    if (configuration != null && !string.IsNullOrEmpty(apiKey))
+                    {
                         apiKeyValidated = false;
                         save = true;
-                        if (_manager == null) {
+                        if (_manager == null)
+                        {
                             managerNullMessage = "Somehow, the manager went missing. Contact a developer!";
                             managerNull = true;
                             PluginReference.InitialzeManager();
                         }
-                        if (_manager != null) {
+                        if (_manager != null)
+                        {
                             managerNullMessage = string.Empty;
                             managerNull = false;
                             Task.Run(() => _manager.ApiValidation(apiKey));
@@ -237,60 +296,79 @@ namespace RoleplayingVoice {
                 IsOpen = false;
             }
             ImGui.SetCursorPos(originPos);
-            if (!string.IsNullOrEmpty(apiKey) && runOnLaunch) {
+            if (!string.IsNullOrEmpty(apiKey) && runOnLaunch)
+            {
                 Task.Run(() => _manager.ApiValidation(apiKey));
                 InputValidation();
                 runOnLaunch = false;
-            } else if (string.IsNullOrEmpty(apiKey)) {
-                if (runOnLaunch) {
+            }
+            else if (string.IsNullOrEmpty(apiKey))
+            {
+                if (runOnLaunch)
+                {
                     InputValidation();
                 }
                 apiKeyErrorMessage = "API Key is empty! Please check the input.";
                 runOnLaunch = false;
             }
             ImGui.BeginChild("ErrorRegion", new Vector2(ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y - 40f), false);
-            if (!isServerIPValid) {
+            if (!isServerIPValid)
+            {
                 ErrorMessage(serverIPErrorMessage);
             }
-            if (!isapiKeyValid || string.IsNullOrEmpty(apiKey)) {
+            if (!isapiKeyValid || string.IsNullOrEmpty(apiKey))
+            {
                 ErrorMessage(apiKeyErrorMessage);
             }
-            if (managerNull) {
+            if (managerNull)
+            {
                 ErrorMessage(managerNullMessage);
             }
             ImGui.EndChild();
         }
 
-        private bool InputValidation() {
-            if (!IPAddress.TryParse(serverIP, out _)) {
+        private bool InputValidation()
+        {
+            if (!IPAddress.TryParse(serverIP, out _))
+            {
                 serverIPErrorMessage = "Invalid Server IP! Please check the input.";
                 isServerIPValid = false;
-            } else {
+            }
+            else
+            {
                 serverIPErrorMessage = string.Empty;
                 isServerIPValid = true;
             }
-            if (isServerIPValid) {
+            if (isServerIPValid)
+            {
                 return true;
             }
             return false;
         }
 
-        private void _manager_OnApiValidationComplete(object sender, ValidationResult e) {
-            if (e.ValidationSuceeded && !apiKeyValidated) {
+        private void _manager_OnApiValidationComplete(object sender, ValidationResult e)
+        {
+            if (e.ValidationSuceeded && !apiKeyValidated)
+            {
                 apiKeyErrorMessage = string.Empty;
                 isapiKeyValid = true;
-            } else if (!e.ValidationSuceeded && !apiKeyValidated) {
+            }
+            else if (!e.ValidationSuceeded && !apiKeyValidated)
+            {
                 apiKeyErrorMessage = "Invalid API Key! Please check the input.";
                 isapiKeyValid = false;
             }
             apiKeyValidated = true;
 
             // If the api key was validated, is valid, and the request was sent via the Save or Close button, the settings are saved.
-            if (isapiKeyValid && save && apiKeyValidated) {
+            if (isapiKeyValid && save && apiKeyValidated)
+            {
                 configuration.ConnectionIP = serverIP;
                 configuration.ApiKey = apiKey;
-                if (clientState.LocalPlayer != null) {
-                    if (configuration.Characters == null) {
+                if (clientState.LocalPlayer != null)
+                {
+                    if (configuration.Characters == null)
+                    {
                         configuration.Characters = new System.Collections.Generic.Dictionary<string, string>();
                     }
                     configuration.Characters[clientState.LocalPlayer.Name.TextValue] = characterVoice != null ? characterVoice : "";
@@ -300,7 +378,6 @@ namespace RoleplayingVoice {
                 configuration.UnfocusedCharacterVolume = _unfocusedCharacterVolume;
                 configuration.IsActive = characterVoiceActive;
                 configuration.UseAggressiveSplicing = _aggressiveCaching;
-                _aggressiveCaching = configuration.UseAggressiveSplicing;
                 PluginInterface.SavePluginConfig(configuration);
                 configuration.Save();
                 RefreshVoices();
@@ -308,16 +385,19 @@ namespace RoleplayingVoice {
             }
         }
 
-        private Vector2? GetSizeChange(float requiredY, float availableY, int Lines, Vector2? initial) {
+        private Vector2? GetSizeChange(float requiredY, float availableY, int Lines, Vector2? initial)
+        {
             // Height
-            if (availableY - requiredY * Lines < 1) {
+            if (availableY - requiredY * Lines < 1)
+            {
                 Vector2? newHeight = new Vector2(initial.Value.X, initial.Value.Y + requiredY * Lines);
                 return newHeight;
             }
             return initial;
         }
 
-        private void ErrorMessage(string message) {
+        private void ErrorMessage(string message)
+        {
             var requiredY = ImGui.CalcTextSize(message).Y + 1f;
             var availableY = ImGui.GetContentRegionAvail().Y;
             var initialH = ImGui.GetCursorPos().Y;
@@ -329,28 +409,38 @@ namespace RoleplayingVoice {
             int textLines = (int)(textHeight / ImGui.GetTextLineHeight());
 
             // Check height and increase if necessarry
-            if (availableY - requiredY * textLines < 1 && !SizeYChanged) {
+            if (availableY - requiredY * textLines < 1 && !SizeYChanged)
+            {
                 SizeYChanged = true;
                 changedSize = GetSizeChange(requiredY, availableY, textLines, initialSize);
                 Size = changedSize;
             }
         }
 
-        public async void RefreshVoices() {
-            if (_manager != null) {
+        public async void RefreshVoices()
+        {
+            if (_manager != null)
+            {
                 _voiceList = await _manager.GetVoiceList();
                 _manager.RefreshElevenlabsSubscriptionInfo();
             }
-            if (clientState.LocalPlayer != null) {
-                if (configuration.Characters == null) {
+            if (clientState.LocalPlayer != null)
+            {
+                if (configuration.Characters == null)
+                {
                     configuration.Characters = new System.Collections.Generic.Dictionary<string, string>();
                 }
-                if (configuration.Characters.ContainsKey(clientState.LocalPlayer.Name.TextValue)) {
-                    if (voiceComboBox != null) {
-                        if (_voiceList != null) {
+                if (configuration.Characters.ContainsKey(clientState.LocalPlayer.Name.TextValue))
+                {
+                    if (voiceComboBox != null)
+                    {
+                        if (_voiceList != null)
+                        {
                             voiceComboBox.Contents = _voiceList;
-                            for (int i = 0; i < voiceComboBox.Contents.Length; i++) {
-                                if (voiceComboBox.Contents[i].Contains(configuration.Characters[clientState.LocalPlayer.Name.TextValue])) {
+                            for (int i = 0; i < voiceComboBox.Contents.Length; i++)
+                            {
+                                if (voiceComboBox.Contents[i].Contains(configuration.Characters[clientState.LocalPlayer.Name.TextValue]))
+                                {
                                     voiceComboBox.SelectedIndex = i;
                                     break;
                                 }
@@ -360,7 +450,8 @@ namespace RoleplayingVoice {
                 }
             }
         }
-        internal class BetterComboBox {
+        internal class BetterComboBox
+        {
             string _label = "";
             int _width = 0;
             int index = -1;
@@ -369,13 +460,16 @@ namespace RoleplayingVoice {
             string[] _contents = new string[1] { "" };
             public event EventHandler OnSelectedIndexChanged;
             public string Text { get { return index > -1 ? _contents[index] : ""; } }
-            public BetterComboBox(string _label, string[] contents, int index, int width = 100) {
-                if (Label != null) {
+            public BetterComboBox(string _label, string[] contents, int index, int width = 100)
+            {
+                if (Label != null)
+                {
                     this._label = _label;
                 }
                 this._width = width;
                 this.index = index;
-                if (contents != null) {
+                if (contents != null)
+                {
                     this._contents = contents;
                 }
             }
@@ -386,21 +480,120 @@ namespace RoleplayingVoice {
             public string Label { get => _label; set => _label = value; }
             public bool Enabled { get => _enabled; set => _enabled = value; }
 
-            public void Draw() {
-                if (_enabled) {
+            public void Draw()
+            {
+                if (_enabled)
+                {
                     ImGui.SetNextItemWidth(ImGui.GetContentRegionMax().X);
-                    if (_label != null && _contents != null) {
-                        if (_contents.Length > 0) {
+                    if (_label != null && _contents != null)
+                    {
+                        if (_contents.Length > 0)
+                        {
                             ImGui.Combo("##" + _label, ref index, _contents, _contents.Length);
                         }
                     }
                 }
-                if (index != _lastIndex) {
-                    if (OnSelectedIndexChanged != null) {
+                if (index != _lastIndex)
+                {
+                    if (OnSelectedIndexChanged != null)
+                    {
                         OnSelectedIndexChanged.Invoke(this, EventArgs.Empty);
                     }
                 }
                 _lastIndex = index;
+            }
+        }
+
+        private void DrawTest()
+        {
+            ImGui.Text("This is a test.");
+
+        }
+
+        private void DrawGeneral()
+        {
+            // Needs changes for new behaviour: show combo at all times
+            // if api isn't valid / validated the only options should be something like "API not initialized"
+            if (isapiKeyValid && clientState.LocalPlayer != null)
+            {
+                if (voiceComboBox != null && _voiceList != null)
+                {
+                    if (_voiceList.Length > 0)
+                    {
+                        ImGui.Text("Voice");
+                        voiceComboBox.Draw();
+                    }
+                }
+                else if (voiceComboBox.Contents.Length == 1 &&
+                    voiceComboBox.Contents[0].Contains("None", StringComparison.OrdinalIgnoreCase) ||
+                    voiceComboBox.Contents[0].Contains("", StringComparison.OrdinalIgnoreCase))
+                {
+                    RefreshVoices();
+                }
+            }
+            else if (voiceComboBox.Contents.Length == 1 && voiceComboBox != null && !isapiKeyValid || clientState.LocalPlayer == null && !isapiKeyValid)
+            {
+                voiceComboBox.Contents[0] = "API not initialized";
+                if (_voiceList.Length > 0)
+                {
+                    ImGui.Text("Voice");
+                    voiceComboBox.Draw();
+                }
+            }
+            else if (clientState.LocalPlayer == null && isapiKeyValid)
+            {
+                voiceComboBox.Contents[0] = "Not logged in";
+                if (_voiceList.Length > 0)
+                {
+                    ImGui.Text("Voice");
+                    voiceComboBox.Draw();
+                }
+            }
+
+            ImGui.SetNextItemWidth(ImGui.GetContentRegionMax().X);
+            ImGui.Checkbox("##characterVoiceActive", ref characterVoiceActive);
+            ImGui.SameLine();
+            ImGui.Text("Voice Enabled");
+
+            if (_manager != null && _manager.Info != null && isapiKeyValid)
+            {
+                ImGui.LabelText("##usage", $"You have used {_manager.Info.CharacterCount}/{_manager.Info.CharacterLimit} characters.");
+                ImGui.TextWrapped($"Once this caps you will either need to upgrade subscription tiers or wait until the next month");
+            }
+        }
+
+        private void DrawVolume()
+        {
+            ////TODO?
+            ImGui.Text("Current Player Voice Volume");
+            ImGui.SetNextItemWidth(ImGui.GetContentRegionMax().X);
+            ImGui.SliderFloat("##playerSlider", ref _playerCharacterVolume, 0, 1);
+            ImGui.Text("Other Player Voice Volume");
+            ImGui.SetNextItemWidth(ImGui.GetContentRegionMax().X);
+            ImGui.SliderFloat("##otherSlider", ref _otherCharacterVolume, 0, 1);
+            ImGui.Text("Unfocused Player Voice Volume");
+            ImGui.SetNextItemWidth(ImGui.GetContentRegionMax().X);
+            ImGui.SliderFloat("##unfocusedVolume", ref _unfocusedCharacterVolume, 0, 1);
+        }
+
+        private void DrawServer()
+        {
+            ImGui.Text("Server IP");
+            ImGui.SetNextItemWidth(ImGui.GetContentRegionMax().X);
+            ImGui.InputText("##serverIP", ref serverIP, 2000);
+
+            ImGui.Text("Elevenlabs API Key");
+            ImGui.SetNextItemWidth(ImGui.GetContentRegionMax().X);
+            ImGui.InputText("##apiKey", ref apiKey, 2000, ImGuiInputTextFlags.Password);
+
+            ImGui.SetNextItemWidth(ImGui.GetContentRegionMax().X);
+            ImGui.Checkbox("##aggressiveCachingActive", ref _aggressiveCaching);
+            ImGui.SameLine();
+            ImGui.Text("Use Aggressive Caching");
+
+            if (ImGui.Button("Reconnect"))
+            {
+                RequestingReconnect?.Invoke(this, EventArgs.Empty);
             }
         }
     }

--- a/RoleplayingVoiceDalamud/RoleplayingVoiceDalamud.csproj
+++ b/RoleplayingVoiceDalamud/RoleplayingVoiceDalamud.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net7.0-windows</TargetFramework>
 		<LangVersion>9.0</LangVersion>
 		<Version>0.0.4.2</Version>
 	</PropertyGroup>


### PR DESCRIPTION
Right now there's one blocking issue, and one minor issue.

- The minor issue is that when the manager is initialized after a cache move, the manager doesn't properly refresh the sub info, so word count will be 0/0 until the window is opened and closed.
- The blocking issue is that right now, when a message is played, it also gets sent to the server, which creates a new file, so the original is unaffected. That new file seems to persist for a while, and results in the cache move being blocked.