### PR TITLE
A few small guards for transient exceptions

### DIFF
--- a/ArtemisRoleplayingKit/CoreLogic/SoundManagement.cs
+++ b/ArtemisRoleplayingKit/CoreLogic/SoundManagement.cs
@@ -389,11 +389,18 @@ namespace RoleplayingVoice {
             if (Conditions.Instance()->InCombat && !Conditions.Instance()->Mounted && !Conditions.Instance()->BoundByDuty) {
                 if (!_combatOccured) {
                     Task.Run(delegate () {
-                        if (_threadSafeObjectTable.LocalPlayer != null) {
+                        var localPlayer = _threadSafeObjectTable.LocalPlayer;
+                        var localPlayerName = localPlayer?.Name.TextValue;
+                        if (config?.CharacterVoicePacks == null || string.IsNullOrEmpty(localPlayerName)) {
+                            // Combat audio is checked from a background task; the local player
+                            // can briefly be missing while logging in, zoning, or unloading.
+                            return;
+                        }
+
+                        if (config.CharacterVoicePacks.TryGetValue(localPlayerName, out string voice)) {
                             _combatOccured = true;
-                            string voice = config.CharacterVoicePacks[_threadSafeObjectTable.LocalPlayer.Name.TextValue];
                             string path = config.CacheFolder + @"\VoicePack\" + voice;
-                            string staging = config.CacheFolder + @"\Staging\" + _threadSafeObjectTable.LocalPlayer.Name.TextValue;
+                            string staging = config.CacheFolder + @"\Staging\" + localPlayerName;
                             if (_mainCharacterVoicePack == null) {
                                 _mainCharacterVoicePack = new CharacterVoicePack(combinedSoundList, DataManager, _clientState.ClientLanguage);
                             }
@@ -442,36 +449,41 @@ namespace RoleplayingVoice {
                 if (Conditions.Instance()->Mounted) {
                     if (!_mountingOccured) {
                         Task.Run(delegate () {
-                            if (_threadSafeObjectTable.LocalPlayer != null) {
-                                if (config.CharacterVoicePacks.ContainsKey(_threadSafeObjectTable.LocalPlayer.Name.TextValue)) {
-                                    string voice = config.CharacterVoicePacks[_threadSafeObjectTable.LocalPlayer.Name.TextValue];
-                                    string path = config.CacheFolder + @"\VoicePack\" + voice;
-                                    string staging = config.CacheFolder + @"\Staging\" + _threadSafeObjectTable.LocalPlayer.Name.TextValue;
-                                    if (_mainCharacterVoicePack == null) {
-                                        _mainCharacterVoicePack = new CharacterVoicePack(combinedSoundList, DataManager, _clientState.ClientLanguage);
-                                    }
-                                    bool isVoicedEmote = false;
-                                    var characterReference = (FFXIVClientStructs.FFXIV.Client.Game.Character.Character*)_threadSafeObjectTable.LocalPlayer.Address;
-                                    var mountId = characterReference->Mount.MountId;
-                                    var mount = DataManager.GetExcelSheet<Mount>(ClientLanguage.English).GetRow(mountId);
-                                    string value = _mainCharacterVoicePack.GetMisc(mount.Singular.ToString());
-                                    if (!string.IsNullOrEmpty(value)) {
-                                        //if (config.UsePlayerSync) {
-                                        //    Task.Run(async () => {
-                                        //        bool success = await _roleplayingMediaManager.SendZip(_threadSafeObjectTable.LocalPlayer.Name.TextValue, staging);
-                                        //    });
-                                        //}
-                                        _mediaManager.PlayMedia(_playerObject, value, SoundType.LoopUntilStopped, false, 0);
-                                        try {
-                                            _gameConfig.Set(SystemConfigOption.IsSndBgm, true);
-                                        } catch (Exception e) {
-                                            Plugin.PluginLog?.Warning(e, e.Message);
-                                        }
-                                        _mountMusicWasPlayed = true;
-                                    }
-                                }
-                                _mountingOccured = true;
+                            var localPlayer = _threadSafeObjectTable.LocalPlayer;
+                            var localPlayerName = localPlayer?.Name.TextValue;
+                            if (config?.CharacterVoicePacks == null || string.IsNullOrEmpty(localPlayerName)) {
+                                // Mount audio uses the same per-character voice-pack map as
+                                // combat audio, so treat missing setup as "no custom audio".
+                                return;
                             }
+
+                            if (config.CharacterVoicePacks.TryGetValue(localPlayerName, out string voice)) {
+                                string path = config.CacheFolder + @"\VoicePack\" + voice;
+                                string staging = config.CacheFolder + @"\Staging\" + localPlayerName;
+                                if (_mainCharacterVoicePack == null) {
+                                    _mainCharacterVoicePack = new CharacterVoicePack(combinedSoundList, DataManager, _clientState.ClientLanguage);
+                                }
+                                bool isVoicedEmote = false;
+                                var characterReference = (FFXIVClientStructs.FFXIV.Client.Game.Character.Character*)localPlayer.Address;
+                                var mountId = characterReference->Mount.MountId;
+                                var mount = DataManager.GetExcelSheet<Mount>(ClientLanguage.English).GetRow(mountId);
+                                string value = _mainCharacterVoicePack.GetMisc(mount.Singular.ToString());
+                                if (!string.IsNullOrEmpty(value)) {
+                                    //if (config.UsePlayerSync) {
+                                    //    Task.Run(async () => {
+                                    //        bool success = await _roleplayingMediaManager.SendZip(_threadSafeObjectTable.LocalPlayer.Name.TextValue, staging);
+                                    //    });
+                                    //}
+                                    _mediaManager.PlayMedia(_playerObject, value, SoundType.LoopUntilStopped, false, 0);
+                                    try {
+                                        _gameConfig.Set(SystemConfigOption.IsSndBgm, true);
+                                    } catch (Exception e) {
+                                        Plugin.PluginLog?.Warning(e, e.Message);
+                                    }
+                                    _mountMusicWasPlayed = true;
+                                }
+                            }
+                            _mountingOccured = true;
                         });
                     }
                 } else {

--- a/ArtemisRoleplayingKit/CoreLogic/SoundManagement.cs
+++ b/ArtemisRoleplayingKit/CoreLogic/SoundManagement.cs
@@ -397,8 +397,11 @@ namespace RoleplayingVoice {
                             return;
                         }
 
+                        // Treat a missing per-character voice-pack entry as "no custom combat
+                        // audio" for this combat cycle so the poller does not keep scheduling
+                        // identical background checks until combat ends.
+                        _combatOccured = true;
                         if (config.CharacterVoicePacks.TryGetValue(localPlayerName, out string voice)) {
-                            _combatOccured = true;
                             string path = config.CacheFolder + @"\VoicePack\" + voice;
                             string staging = config.CacheFolder + @"\Staging\" + localPlayerName;
                             if (_mainCharacterVoicePack == null) {

--- a/ArtemisRoleplayingKit/CoreLogic/SoundManagement.cs
+++ b/ArtemisRoleplayingKit/CoreLogic/SoundManagement.cs
@@ -1704,10 +1704,17 @@ namespace RoleplayingVoice {
         }
 
         private void SendingMovement(string playerName, IGameObject gameObject) {
-            if (config.CharacterVoicePacks.ContainsKey(_threadSafeObjectTable.LocalPlayer.Name.TextValue)) {
-                string voice = config.CharacterVoicePacks[_threadSafeObjectTable.LocalPlayer.Name.TextValue];
+            var localPlayer = _threadSafeObjectTable.LocalPlayer;
+            var localPlayerName = localPlayer?.Name.TextValue;
+            if (config?.CharacterVoicePacks == null || string.IsNullOrEmpty(localPlayerName)) {
+                // Movement checks run from a background poll, so local-player
+                // state can disappear briefly during login/logout or zoning.
+                return;
+            }
+
+            if (config.CharacterVoicePacks.TryGetValue(localPlayerName, out string voice)) {
                 string path = config.CacheFolder + @"\VoicePack\" + voice;
-                string staging = config.CacheFolder + @"\Staging\" + _threadSafeObjectTable.LocalPlayer.Name.TextValue;
+                string staging = config.CacheFolder + @"\Staging\" + localPlayerName;
                 if (_mainCharacterVoicePack == null) {
                     _mainCharacterVoicePack = new CharacterVoicePack(combinedSoundList, DataManager, _clientState.ClientLanguage);
                 }

--- a/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
+++ b/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
@@ -952,11 +952,21 @@ namespace RoleplayingVoiceDalamud.Voice {
                             }
                         }
                         if (_plugin.Window.NpcSpeechEnabled && !onlySendData) {
-                            if (stream != null) {
+                            // GetCharacterAudio can fail without throwing and still leave a non-null MemoryStream.
+                            // MediaFoundation throws a COMException for empty or non-audio streams, so validate the
+                            // request result before handing the stream to NAudio for decoding.
+                            if (values.Item1 && stream != null && stream.Length > 1) {
                                 if (_plugin.Config.DebugMode) {
                                     _plugin.Chat.Print("Stream is valid! Download took " + downloadTimer.Elapsed.ToString());
                                 }
-                                WaveStream wavePlayer = _plugin.NpcVoiceManager.StreamToFoundationReader(stream);
+                                WaveStream wavePlayer = null;
+                                try {
+                                    stream.Position = 0;
+                                    wavePlayer = _plugin.NpcVoiceManager.StreamToFoundationReader(stream);
+                                } catch (System.Runtime.InteropServices.COMException e) {
+                                    Plugin.PluginLog.Warning(e, "Skipping NPC voice playback because MediaFoundation could not decode the generated audio stream.");
+                                    return;
+                                }
                                 ActorMemory actorMemory = null;
                                 AnimationMemory animationMemory = null;
                                 ActorMemory.CharacterModes initialState = ActorMemory.CharacterModes.None;
@@ -1000,6 +1010,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                                     }
                                 }
                             } else {
+                                Plugin.PluginLog.Warning($"Skipping NPC voice playback because no playable audio was returned for {nameToUse}. Success={values.Item1}, StreamLength={stream?.Length ?? 0}, Engine={values.Item2}");
                                 if (_plugin.Config.DebugMode) {
                                     _plugin.Chat.Print("Stream was null! Download took " + downloadTimer.Elapsed.ToString());
                                 }

--- a/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
+++ b/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
@@ -959,12 +959,8 @@ namespace RoleplayingVoiceDalamud.Voice {
                                 if (_plugin.Config.DebugMode) {
                                     _plugin.Chat.Print("Stream is valid! Download took " + downloadTimer.Elapsed.ToString());
                                 }
-                                WaveStream wavePlayer = null;
-                                try {
-                                    stream.Position = 0;
-                                    wavePlayer = _plugin.NpcVoiceManager.StreamToFoundationReader(stream);
-                                } catch (System.Runtime.InteropServices.COMException e) {
-                                    Plugin.PluginLog.Warning(e, "Skipping NPC voice playback because MediaFoundation could not decode the generated audio stream.");
+                                WaveStream wavePlayer = TryCreateNpcWavePlayer(stream, nameToUse, "explicit voice");
+                                if (wavePlayer == null) {
                                     return;
                                 }
                                 ActorMemory actorMemory = null;
@@ -1078,11 +1074,11 @@ namespace RoleplayingVoiceDalamud.Voice {
                                     _npcVoiceHistoryItems.RemoveAt(0);
                                 }
                             }
-                            if (stream != null && stream.Length > 1 && _plugin.Window.NpcSpeechEnabled) {
+                            if (values.Item1 && stream != null && stream.Length > 1 && _plugin.Window.NpcSpeechEnabled) {
                                 if (_plugin.Config.DebugMode) {
                                     _plugin.Chat.Print("Stream is valid! Download took " + downloadTimer.Elapsed.ToString());
                                 }
-                                WaveStream wavePlayer = _plugin.NpcVoiceManager.StreamToFoundationReader(stream);
+                                WaveStream wavePlayer = TryCreateNpcWavePlayer(stream, nameToUse, "NPC dialogue");
                                 ActorMemory actorMemory = null;
                                 AnimationMemory animationMemory = null;
                                 ActorMemory.CharacterModes initialState = ActorMemory.CharacterModes.None;
@@ -1219,6 +1215,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                                     }
                                 }
                             } else {
+                                Plugin.PluginLog.Warning($"Skipping NPC voice playback because no playable audio was returned for {nameToUse}. Success={values.Item1}, StreamLength={stream?.Length ?? 0}, Engine={values.Item2}");
                                 if (_plugin.Config.DebugMode) {
                                     _plugin.Chat.Print("Stream was null! trying again. " + downloadTimer.Elapsed.ToString());
                                 }
@@ -1234,6 +1231,19 @@ namespace RoleplayingVoiceDalamud.Voice {
                         _plugin.Chat.Print(e.Message);
                     }
                 }
+            }
+        }
+
+        private WaveStream TryCreateNpcWavePlayer(Stream stream, string npcName, string playbackPath) {
+            // GetCharacterAudio can report success with bytes that MediaFoundation cannot decode
+            // on some machines/codecs. Keep that failure local to this line instead of letting
+            // a COMException unwind the async NPC playback task.
+            try {
+                stream.Position = 0;
+                return _plugin.NpcVoiceManager.StreamToFoundationReader(stream);
+            } catch (System.Runtime.InteropServices.COMException e) {
+                Plugin.PluginLog.Warning(e, $"Skipping {playbackPath} playback for {npcName} because MediaFoundation could not decode the generated audio stream. StreamLength={stream.Length}");
+                return null;
             }
         }
 
@@ -1292,8 +1302,11 @@ namespace RoleplayingVoiceDalamud.Voice {
                     }
                     var values =
                     await _plugin.NpcVoiceManager.GetCharacterAudio(stream, value, StripPlayerNameFromNPCDialogueArc(message), initialConvertedString, nameToUse, gender, voice, false, voiceModel, npcData, false, false, canBeMuted, conditionsForDatamining);
-                    if (stream != null && _plugin.Window.NpcSpeechEnabled) {
-                        WaveStream wavePlayer = _plugin.NpcVoiceManager.StreamToFoundationReader(stream);
+                    if (values.Item1 && stream != null && stream.Length > 1 && _plugin.Window.NpcSpeechEnabled) {
+                        WaveStream wavePlayer = TryCreateNpcWavePlayer(stream, nameToUse, "object/bubble dialogue");
+                        if (wavePlayer == null) {
+                            return;
+                        }
                         bool useSmbPitch = CheckIfshouldUseSmbPitch(nameToUse, body);
                         float pitch = values.Item1 ? CheckForDefinedPitch(nameToUse) :
                          CalculatePitchBasedOnTraits(nameToUse, gender, race, body, 0.09f);

--- a/ArtemisRoleplayingKit/Windows/PluginWindow.cs
+++ b/ArtemisRoleplayingKit/Windows/PluginWindow.cs
@@ -879,7 +879,14 @@ namespace RoleplayingVoice {
             Task.Run(async delegate () {
                 _refreshing = true;
                 try {
-                    if (PluginReference.ThreadSafeObjectTable.LocalPlayer != null) {
+                    var playerName = PluginReference?.ThreadSafeObjectTable?.LocalPlayer?.Name.TextValue;
+                    if (!string.IsNullOrWhiteSpace(playerName) && configuration != null) {
+                        // RefreshVoices awaits relay/API calls below. Snapshot the player name
+                        // up front so login, logout, or zoning cannot invalidate LocalPlayer
+                        // between the initial guard and the later voice-setting reads.
+                        if (configuration.Characters == null) {
+                            configuration.Characters = new System.Collections.Generic.Dictionary<string, string>();
+                        }
                         List<string> voicePacks = new List<string>();
                         string path = cacheFolder + @"\VoicePack\";
                         if (Directory.Exists(path)) {
@@ -889,29 +896,29 @@ namespace RoleplayingVoice {
                                 }
                             }
                             _voicePackList = voicePacks.ToArray();
-                            if (voicePacks.Count > voicePackComboBox.Contents.Length) {
+                            if (voicePackComboBox != null && voicePacks.Count > voicePackComboBox.Contents.Length) {
                                 voicePackComboBox.Contents = _voicePackList;
                             }
                         }
                         if (configuration.CharacterVoicePacks == null) {
                             configuration.CharacterVoicePacks = new System.Collections.Generic.Dictionary<string, string>();
                         }
-                        if (configuration.CharacterVoicePacks.ContainsKey(PluginReference.ThreadSafeObjectTable.LocalPlayer.Name.TextValue)) {
+                        if (configuration.CharacterVoicePacks.TryGetValue(playerName, out var configuredVoicePack)) {
                             if (voicePackComboBox != null) {
                                 if (_voicePackList != null) {
                                     if (voiceComboBox != null) {
                                         voicePackComboBox.Contents = _voicePackList;
                                         if (voicePackComboBox.Contents.Length > 0) {
                                             for (int i = 0; i < voicePackComboBox.Contents.Length; i++) {
-                                                if (voicePackComboBox.Contents[i].Contains(configuration.CharacterVoicePacks[PluginReference.ThreadSafeObjectTable.LocalPlayer.Name.TextValue])) {
+                                                if (voicePackComboBox.Contents[i].Contains(configuredVoicePack)) {
                                                     voicePackComboBox.SelectedIndex = i;
                                                     break;
                                                 }
                                             }
                                             try {
-                                                if (string.IsNullOrWhiteSpace(configuration.CharacterVoicePacks[PluginReference.ThreadSafeObjectTable.LocalPlayer.Name.TextValue])) {
+                                                if (string.IsNullOrWhiteSpace(configuredVoicePack)) {
                                                     if (voicePackComboBox.SelectedIndex < voicePackComboBox.Contents.Length) {
-                                                        configuration.CharacterVoicePacks[PluginReference.ThreadSafeObjectTable.LocalPlayer.Name.TextValue] = voicePackComboBox.Contents[voicePackComboBox.SelectedIndex];
+                                                        configuration.CharacterVoicePacks[playerName] = voicePackComboBox.Contents[voicePackComboBox.SelectedIndex];
                                                     }
                                                 }
                                             } catch {
@@ -937,43 +944,43 @@ namespace RoleplayingVoice {
                             }
                             if (newVoiceList != null && newVoiceList.Length > 0) {
                                 _voiceList = newVoiceList;
-                                voiceComboBox.Contents = newVoiceList;
+                                if (voiceComboBox != null) {
+                                    voiceComboBox.Contents = newVoiceList;
+                                }
                             }
-                            switch (_voiceEngineComboBox.SelectedIndex) {
-                                case 0:
-                                    _manager.SetVoiceElevenlabs(Configuration.Characters[PluginReference.ThreadSafeObjectTable.LocalPlayer.Name.TextValue]);
-                                    _manager.RefreshElevenlabsSubscriptionInfo();
-                                    break;
-                                case 1:
-                                    _manager.SetVoiceXTTS(Configuration.Characters[PluginReference.ThreadSafeObjectTable.LocalPlayer.Name.TextValue]);
-                                    break;
-                                case 2:
-                                    _manager.SetVoiceMicrosoftNarrator(Configuration.Characters[PluginReference.ThreadSafeObjectTable.LocalPlayer.Name.TextValue]);
-                                    break;
+                            if (configuration.Characters.TryGetValue(playerName, out var configuredVoice)) {
+                                switch (_voiceEngineComboBox.SelectedIndex) {
+                                    case 0:
+                                        _manager.SetVoiceElevenlabs(configuredVoice);
+                                        _manager.RefreshElevenlabsSubscriptionInfo();
+                                        break;
+                                    case 1:
+                                        _manager.SetVoiceXTTS(configuredVoice);
+                                        break;
+                                    case 2:
+                                        _manager.SetVoiceMicrosoftNarrator(configuredVoice);
+                                        break;
+                                }
                             }
-                            if (_voiceList != null && _voiceList.Length > 0) {
+                            if (voiceComboBox != null && _voiceList != null && _voiceList.Length > 0) {
                                 voiceComboBox.Contents = _voiceList;
                             }
                         }
-                        if (configuration.Characters == null) {
-                            configuration.Characters = new System.Collections.Generic.Dictionary<string, string>();
-                        }
-                        if (configuration.Characters.ContainsKey(PluginReference.ThreadSafeObjectTable.LocalPlayer.Name.TextValue)) {
+                        if (configuration.Characters.TryGetValue(playerName, out var configuredCharacterVoice)) {
                             if (voiceComboBox != null) {
                                 if (_voiceList != null && _voiceList.Length > 0) {
                                     voiceComboBox.Contents = _voiceList;
                                     if (voiceComboBox.Contents.Length > 0) {
                                         for (int i = 0; i < voiceComboBox.Contents.Length; i++) {
-                                            string value = configuration.Characters[PluginReference.ThreadSafeObjectTable.LocalPlayer.Name.TextValue];
-                                            if (voiceComboBox.Contents[i].Contains(value) && !string.IsNullOrEmpty(value)) {
+                                            if (voiceComboBox.Contents[i].Contains(configuredCharacterVoice) && !string.IsNullOrEmpty(configuredCharacterVoice)) {
                                                 voiceComboBox.SelectedIndex = i;
                                                 break;
                                             }
                                         }
                                         try {
-                                            if (string.IsNullOrWhiteSpace(configuration.Characters[PluginReference.ThreadSafeObjectTable.LocalPlayer.Name.TextValue])) {
+                                            if (string.IsNullOrWhiteSpace(configuration.Characters[playerName])) {
                                                 if (voiceComboBox.SelectedIndex < voiceComboBox.Contents.Length) {
-                                                    configuration.Characters[PluginReference.ThreadSafeObjectTable.LocalPlayer.Name.TextValue] = voiceComboBox.Contents[voiceComboBox.SelectedIndex];
+                                                    configuration.Characters[playerName] = voiceComboBox.Contents[voiceComboBox.SelectedIndex];
                                                 }
                                             }
                                         } catch {

--- a/ArtemisRoleplayingKit/Windows/PluginWindow.cs
+++ b/ArtemisRoleplayingKit/Windows/PluginWindow.cs
@@ -929,9 +929,13 @@ namespace RoleplayingVoice {
                                 }
                             }
                         }
-                        if (_manager != null) {
+                        if (_manager != null && _voiceEngineComboBox != null) {
+                            // RefreshVoices can run while the settings window is still
+                            // constructing its controls, so wait until the engine selector
+                            // exists before reading the selected voice backend.
+                            var selectedVoiceEngine = _voiceEngineComboBox.SelectedIndex;
                             var newVoiceList = new string[] { "None" };
-                            switch (_voiceEngineComboBox.SelectedIndex) {
+                            switch (selectedVoiceEngine) {
                                 case 0:
                                     newVoiceList = await _manager.GetVoiceListElevenlabs();
                                     break;
@@ -949,7 +953,7 @@ namespace RoleplayingVoice {
                                 }
                             }
                             if (configuration.Characters.TryGetValue(playerName, out var configuredVoice)) {
-                                switch (_voiceEngineComboBox.SelectedIndex) {
+                                switch (selectedVoiceEngine) {
                                     case 0:
                                         _manager.SetVoiceElevenlabs(configuredVoice);
                                         _manager.RefreshElevenlabsSubscriptionInfo();


### PR DESCRIPTION
Intent: prevent plugin background tasks and settings refreshes from throwing when player/config state changes during login, zoning, or partially configured voice-pack setup.

- Guarded movement voice-pack lookup in SoundManagement.cs by snapshotting the local player name and using TryGetValue instead of indexing CharacterVoicePacks directly.
- Applied the same safe lookup pattern to custom combat audio and custom mount audio.
- Treated missing per-character voice-pack entries as “no custom audio configured” rather than an exception.
Guarded PluginWindow.RefreshVoices() against LocalPlayer becoming unavailable while async voice-list/API calls are in progress.
- Initialized and checked character voice dictionaries before use, avoiding direct dictionary indexing when a player entry is absent.