### PR TITLE
Deduplicate talk state logging

### DIFF
--- a/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
+++ b/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
@@ -86,6 +86,9 @@ namespace RoleplayingVoiceDalamud.Voice {
         private string _lastSoundPath;
         bool _blockNpcChat = false;
         private List<NPCVoiceHistoryItem> _npcVoiceHistoryItems = new List<NPCVoiceHistoryItem>();
+        private bool _lastLoggedTalkStateWasPresent;
+        private string _lastLoggedTalkStateSpeaker = "";
+        private string _lastLoggedTalkStateText = "";
 
         ////public List<ActionTimeline> LipSyncTypes { get; private set; }
 
@@ -538,9 +541,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                                         if (_state == null) {
                                             _state = GetBattleTalkAddonState();
                                         }
-                                        if (_state != null) {
-                                            Plugin.PluginLog.Information($"[DEBUG] Talk state detected - Speaker: {_state.Speaker}, Text: {_state.Text?.Substring(0, Math.Min(50, _state.Text?.Length ?? 0))}");
-                                        }
+                                        LogTalkStateIfChanged(_state);
                                         Task.Run((Action)delegate {
                                             if (!_alreadySortingList) {
                                                 _alreadySortingList = true;
@@ -624,6 +625,29 @@ namespace RoleplayingVoiceDalamud.Voice {
                         }
                     }
                 }
+        }
+
+        private void LogTalkStateIfChanged(AddonTalkState state) {
+            if (state == null) {
+                _lastLoggedTalkStateWasPresent = false;
+                return;
+            }
+
+            var speaker = state.Speaker ?? "";
+            var text = state.Text ?? "";
+            if (_lastLoggedTalkStateWasPresent &&
+                speaker == _lastLoggedTalkStateSpeaker &&
+                text == _lastLoggedTalkStateText) {
+                return;
+            }
+
+            _lastLoggedTalkStateWasPresent = true;
+            _lastLoggedTalkStateSpeaker = speaker;
+            _lastLoggedTalkStateText = text;
+
+            // Framework_Update polls while the same dialogue window is visible,
+            // so log only state changes to avoid flooding Dalamud's shared log.
+            Plugin.PluginLog.Information($"[DEBUG] Talk state detected - Speaker: {speaker}, Text: {text.Substring(0, Math.Min(50, text.Length))}");
         }
 
         private void GetAnimationDefaults() {


### PR DESCRIPTION
Currently, we re-write the same logs over and over in the main dalamud log while talk state is active. We only really need to write once per state change 