### PR TITLE
Make NPC TTS Fail Fast and Move On

### DIFF
--- a/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
+++ b/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
@@ -545,8 +545,8 @@ namespace RoleplayingVoiceDalamud.Voice {
                                         if (_state != null) {
                                             Plugin.PluginLog.Information($"[DEBUG] Talk state detected - Speaker: {_state.Speaker}, Text: {_state.Text?.Substring(0, Math.Min(50, _state.Text?.Length ?? 0))}");
                                         }
+                                        var stateSnapshot = _state;
                                         Task.Run((Action)delegate {
-                                            var stateSnapshot = _state;
                                             if (!_alreadySortingList) {
                                                 _alreadySortingList = true;
                                                 _sortedObjectTable = _threadSafeObjectTable.ToList();
@@ -564,7 +564,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                                                     CancelNpcVoiceRequests("talk state text changed");
                                                     _currentText = stateSnapshot.Text;
                                                     _redoLineWindow.IsOpen = false;
-                                                    TraceNpcTts($"Talk state accepted speaker='{stateSnapshot.Speaker}' block={_blockAudioGeneration} blockCount={_blockAudioGenerationCount} text='{PreviewText(stateSnapshot.Text)}'");
+                                                    TraceNpcTtsDebug($"Talk state accepted speaker='{stateSnapshot.Speaker}' block={_blockAudioGeneration} blockCount={_blockAudioGenerationCount} text='{PreviewText(stateSnapshot.Text)}'");
                                                     if (!_blockAudioGeneration) {
                                                         var speaker = NPCVoiceMapping.AliasDetector(stateSnapshot.Speaker);
                                                         TraceNpcTts($"Dispatching dialogue to NPCText speaker='{speaker}' text='{PreviewText(stateSnapshot.Text)}'");
@@ -583,7 +583,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                                                     _blockAudioGeneration = false;
                                                 }
                                             } else if (stateSnapshot != null) {
-                                                TraceNpcTts($"Ignored talk state speaker='{stateSnapshot.Speaker}' textPresent={!string.IsNullOrEmpty(stateSnapshot.Text)} text='{PreviewText(stateSnapshot.Text)}'");
+                                                TraceNpcTtsDebug($"Ignored talk state speaker='{stateSnapshot.Speaker}' textPresent={!string.IsNullOrEmpty(stateSnapshot.Text)} text='{PreviewText(stateSnapshot.Text)}'");
                                             } else {
                                                 if (_currentDialoguePaths.Count > 0) {
                                                     if (!_currentDialoguePaths[_currentDialoguePaths.ElementAt(_currentDialoguePaths.Count - 1).Key] &&
@@ -605,18 +605,27 @@ namespace RoleplayingVoiceDalamud.Voice {
                                                         _currentDialoguePaths[_currentDialoguePaths.ElementAt(_currentDialoguePaths.Count - 1).Key] = true;
                                                     }
                                                 }
-                                                if (_currentSpeechObject != null && _startedNewDialogue) {
+                                                if (_startedNewDialogue) {
                                                     CancelNpcVoiceRequests("talk state cleared while dialogue was active");
-                                                    var otherData = this._threadSafeObjectTable.LocalPlayer.OnlineStatus;
-                                                    if (otherData.Value.RowId != 15) {
+                                                    if (_currentSpeechObject != null) {
+                                                        var speechObject = _currentSpeechObject;
+                                                        var localPlayer = _threadSafeObjectTable.LocalPlayer;
+                                                        if (localPlayer == null || localPlayer.OnlineStatus.Value.RowId != 15) {
+                                                            _namesToRemove.Clear();
+                                                            _currentText = "";
+                                                            _currentSpeechObject = null;
+                                                            _currentDialoguePaths.Clear();
+                                                        }
+                                                        if (!IsInACutscene() && !_plugin.Config.AllowDialogueQueuingOutsideCutscenes) {
+                                                            _plugin.MediaManager.StopAudio(speechObject);
+                                                            _plugin.MediaManager.CleanSounds();
+                                                        }
+                                                    } else {
+                                                        // A relay request can still be pending before playback has
+                                                        // created a speech object, so clear the text gate here too.
                                                         _namesToRemove.Clear();
                                                         _currentText = "";
-                                                        _currentSpeechObject = null;
                                                         _currentDialoguePaths.Clear();
-                                                    }
-                                                    if (!IsInACutscene() && !_plugin.Config.AllowDialogueQueuingOutsideCutscenes) {
-                                                        _plugin.MediaManager.StopAudio(_currentSpeechObject);
-                                                        _plugin.MediaManager.CleanSounds();
                                                     }
                                                     _startedNewDialogue = false;
                                                     _redoLineWindow.IsOpen = false;
@@ -650,8 +659,14 @@ namespace RoleplayingVoiceDalamud.Voice {
 
         private static void TraceNpcTts(string message) {
             // These breadcrumbs are intentionally logged only at dialogue handoff
-            // boundaries, not every poll, so test logs show where a line was dropped.
+            // and suppression boundaries, not every internal success step.
             Plugin.PluginLog.Information("[NPC TTS] " + message);
+        }
+
+        private static void TraceNpcTtsDebug(string message) {
+            // Detailed success-path state is useful while diagnosing relay issues,
+            // but should not expand normal Dalamud logs for every spoken line.
+            Plugin.PluginLog.Debug("[NPC TTS] " + message);
         }
 
         private void GetAnimationDefaults() {
@@ -797,7 +812,9 @@ namespace RoleplayingVoiceDalamud.Voice {
             lock (_npcVoiceRequestLock) {
                 // NPC dialogue is ephemeral: once a newer line arrives, any older
                 // relay response would play stale audio and should be abandoned.
-                _npcVoiceRequestCancellation.Cancel();
+                var previousRequestCancellation = _npcVoiceRequestCancellation;
+                previousRequestCancellation.Cancel();
+                previousRequestCancellation.Dispose();
                 _npcVoiceRequestCancellation = new CancellationTokenSource();
                 _npcVoiceRequestSequence++;
                 TraceNpcTts($"Started request sequence={_npcVoiceRequestSequence} reason='{reason}'");
@@ -1105,7 +1122,7 @@ namespace RoleplayingVoiceDalamud.Voice {
             }
 
             try {
-                    TraceNpcTts($"NPCText entered npc='{npcName}' lowLatency={lowLatencyMode} redo={redoLine} priority={voiceLinePriority} block={_blockAudioGeneration} enabled={_plugin.Window.NpcSpeechEnabled} text='{PreviewText(message)}'");
+                    TraceNpcTtsDebug($"NPCText entered npc='{npcName}' lowLatency={lowLatencyMode} redo={redoLine} priority={voiceLinePriority} block={_blockAudioGeneration} enabled={_plugin.Window.NpcSpeechEnabled} text='{PreviewText(message)}'");
                     bool gender = false;
                     byte race = 0;
                     int body = 0;
@@ -1113,16 +1130,23 @@ namespace RoleplayingVoiceDalamud.Voice {
                     Dalamud.Game.ClientState.Objects.Types.IGameObject npcObject = DiscoverNpc(npcName, message, ref gender, ref race, ref body, ref isRetainer);
                     if (!isRetainer || (_plugin != null && !_plugin.Config.DontVoiceRetainers)) {
                         string nameToUse = NPCVoiceMapping.CheckForNameVariant(npcObject == null || npcName != "???" ? npcName : npcObject.Name.TextValue, _clientState.TerritoryType);
-                        MediaGameObject currentSpeechObject = new MediaGameObject(npcObject != null ? npcObject.ToThreadSafeObject() : _threadSafeObjectTable.LocalPlayer);
+                        var localPlayer = _threadSafeObjectTable.LocalPlayer;
+                        var localPlayerName = localPlayer?.Name.TextValue;
+                        MediaGameObject currentSpeechObject = new MediaGameObject(npcObject != null ? npcObject.ToThreadSafeObject() : localPlayer);
                         _currentSpeechObject = currentSpeechObject;
                         bool foundName = false;
                         bool isExtra = false;
                         bool isTerritorySpecific = false;
                         string initialCleanedValue = PhoneticLexiconCorrection(ConvertRomanNumberals(message));
-                        string value = FeoUlRetainerCleanup(nameToUse, StripPlayerNameFromNPCDialogue(initialCleanedValue, _threadSafeObjectTable.LocalPlayer.Name.TextValue, ref foundName));
+                        // LocalPlayer can briefly disappear while zoning or loading; keep the
+                        // original NPC line instead of dropping playback while stripping names.
+                        var playerStrippedValue = !string.IsNullOrWhiteSpace(localPlayerName)
+                            ? StripPlayerNameFromNPCDialogue(initialCleanedValue, localPlayerName, ref foundName)
+                            : initialCleanedValue;
+                        string value = FeoUlRetainerCleanup(nameToUse, playerStrippedValue);
                         string arcValue = FeoUlRetainerCleanup(nameToUse, StripPlayerNameFromNPCDialogueArc(message));
                         string backupVoice = PickVoiceBasedOnTraits(nameToUse, gender, race, body, ref isExtra, ref isTerritorySpecific);
-                        TraceNpcTts($"NPCText prepared npc='{nameToUse}' discoveredObject={npcObject != null} retainer={isRetainer} gender={gender} race={race} body={body} backupVoice='{backupVoice}' extra={isExtra} territorySpecific={isTerritorySpecific} text='{PreviewText(value)}'");
+                        TraceNpcTtsDebug($"NPCText prepared npc='{nameToUse}' discoveredObject={npcObject != null} retainer={isRetainer} gender={gender} race={race} body={body} backupVoice='{backupVoice}' extra={isExtra} territorySpecific={isTerritorySpecific} text='{PreviewText(value)}'");
                         ReportData reportData = new ReportData(npcName, value, npcObject, _clientState.TerritoryType, note);
                         string npcData = JsonConvert.SerializeObject(reportData);
                         Stopwatch downloadTimer = Stopwatch.StartNew();
@@ -1159,7 +1183,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                                 }
                             }
                             if (stream != null && stream.Length > 1 && _plugin.Window.NpcSpeechEnabled) {
-                                TraceNpcTts($"Audio stream ready sequence={request.Sequence} npc='{nameToUse}' engine='{values.Item2}' length={stream.Length}");
+                                TraceNpcTtsDebug($"Audio stream ready sequence={request.Sequence} npc='{nameToUse}' engine='{values.Item2}' length={stream.Length}");
                                 if (_plugin.Config.DebugMode) {
                                     _plugin.Chat.Print("Stream is valid! Download took " + downloadTimer.Elapsed.ToString());
                                 }
@@ -1204,7 +1228,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                                     }
                                     unsafe {
                                         if (!_blockAudioGeneration) {
-                                            TraceNpcTts($"Playing audio sequence={request.Sequence} npc='{nameToUse}' engine='{values.Item2}' pitch={pitch:F3} speed={_plugin.Config.NPCSpeechSpeed:F2}");
+                                            TraceNpcTtsDebug($"Playing audio sequence={request.Sequence} npc='{nameToUse}' engine='{values.Item2}' pitch={pitch:F3} speed={_plugin.Config.NPCSpeechSpeed:F2}");
                                             _plugin.MediaManager.PlayAudioStream(_currentSpeechObject, wavePlayer, SoundType.NPC,
                                            (IsInACutscene() && Conditions.Instance()->BoundByDuty), useSmbPitch, pitch, 0,
                                             IsInACutscene() || lowLatencyMode, delegate (object obj, string value) {

--- a/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
+++ b/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
@@ -86,6 +86,9 @@ namespace RoleplayingVoiceDalamud.Voice {
         private string _lastSoundPath;
         bool _blockNpcChat = false;
         private List<NPCVoiceHistoryItem> _npcVoiceHistoryItems = new List<NPCVoiceHistoryItem>();
+        private bool _lastLoggedTalkStateWasPresent;
+        private string _lastLoggedTalkStateSpeaker = "";
+        private string _lastLoggedTalkStateText = "";
 
         ////public List<ActionTimeline> LipSyncTypes { get; private set; }
 
@@ -108,6 +111,9 @@ namespace RoleplayingVoiceDalamud.Voice {
         Queue<KeyValuePair<string, string>> _npcDungeonDialogueQueue = new Queue<KeyValuePair<string, string>>();
         List<string> _knownNPCBossAnnouncers = new List<string>();
         List<string> _knownNPCAnnouncers = new List<string>();
+        private readonly object _npcVoiceRequestLock = new object();
+        private CancellationTokenSource _npcVoiceRequestCancellation = new CancellationTokenSource();
+        private long _npcVoiceRequestSequence;
 
         public AddonTalkHandler(AddonTalkManager addonTalkManager, IFramework framework, ThreadSafeGameObjectManager objects,
             IClientState clientState, Plugin plugin, IChatGui chatGui, ISigScanner sigScanner, RedoLineWindow redoLineWindow, IToastGui toastGui) {
@@ -345,13 +351,14 @@ namespace RoleplayingVoiceDalamud.Voice {
                                             Thread.Sleep(1000);
                                             _blockAudioGenerationCount--;
                                         });
-                                    }
-                                    _blockAudioGeneration = e.isBlocking;
-                                    _lastNPCAnnouncementName = null;
-                                    _currentDialoguePaths[e.SoundPath] = false;
-                                    if (_plugin.Config.DebugMode) {
-                                        if (_lastNPCAnnouncementName != null) {
-                                            DumpCurrentAudio(_lastNPCAnnouncementName);
+	                                    }
+	                                    _blockAudioGeneration = e.isBlocking;
+	                                    _lastNPCAnnouncementName = null;
+	                                    _currentDialoguePaths[e.SoundPath] = false;
+	                                    TraceNpcTts($"Cutscene audio filter changed block={e.isBlocking} blockCount={_blockAudioGenerationCount} sound='{e.SoundPath}'");
+	                                    if (_plugin.Config.DebugMode) {
+	                                        if (_lastNPCAnnouncementName != null) {
+	                                            DumpCurrentAudio(_lastNPCAnnouncementName);
                                         }
                                         _plugin.Chat.Print("Block Next Line Of Dialogue Is " + e.isBlocking);
                                         _plugin.Chat.Print("Dialogue block created by " + e.SoundPath);
@@ -538,9 +545,8 @@ namespace RoleplayingVoiceDalamud.Voice {
                                         if (_state == null) {
                                             _state = GetBattleTalkAddonState();
                                         }
-                                        if (_state != null) {
-                                            Plugin.PluginLog.Information($"[DEBUG] Talk state detected - Speaker: {_state.Speaker}, Text: {_state.Text?.Substring(0, Math.Min(50, _state.Text?.Length ?? 0))}");
-                                        }
+                                        var stateSnapshot = _state;
+                                        LogTalkStateIfChanged(stateSnapshot);
                                         Task.Run((Action)delegate {
                                             if (!_alreadySortingList) {
                                                 _alreadySortingList = true;
@@ -552,25 +558,33 @@ namespace RoleplayingVoiceDalamud.Voice {
                                                 }
                                                 _alreadySortingList = false;
                                             }
-                                            if (_state != null && !string.IsNullOrEmpty(_state.Text) && _state.Speaker != "All") {
+                                            if (stateSnapshot != null && !string.IsNullOrEmpty(stateSnapshot.Text) && stateSnapshot.Speaker != "All") {
                                                 _textIsPresent = true;
-                                                if (_state.Text != _currentText) {
+                                                if (stateSnapshot.Text != _currentText) {
                                                     _lastText = _currentText;
-                                                    _currentText = _state.Text;
+                                                    CancelNpcVoiceRequests("talk state text changed");
+                                                    _currentText = stateSnapshot.Text;
                                                     _redoLineWindow.IsOpen = false;
+                                                    TraceNpcTts($"Talk state accepted speaker='{stateSnapshot.Speaker}' block={_blockAudioGeneration} blockCount={_blockAudioGenerationCount} text='{PreviewText(stateSnapshot.Text)}'");
                                                     if (!_blockAudioGeneration) {
-                                                        NPCText(NPCVoiceMapping.AliasDetector(_state.Speaker), _state.Text.TrimStart('.'), false, NPCVoiceManager.VoiceModel.Speed, true);
+                                                        var speaker = NPCVoiceMapping.AliasDetector(stateSnapshot.Speaker);
+                                                        TraceNpcTts($"Dispatching dialogue to NPCText speaker='{speaker}' text='{PreviewText(stateSnapshot.Text)}'");
+                                                        NPCText(speaker, stateSnapshot.Text.TrimStart('.'), false, NPCVoiceManager.VoiceModel.Speed, true);
                                                         _startedNewDialogue = true;
                                                         _passthroughTimer.Reset();
+                                                    } else {
+                                                        TraceNpcTts($"Suppressed dialogue generation because blockAudioGeneration is true speaker='{stateSnapshot.Speaker}' text='{PreviewText(stateSnapshot.Text)}'");
                                                     }
                                                     if (_plugin.Config.DebugMode) {
-                                                        DumpCurrentAudio(_state.Speaker);
+                                                        DumpCurrentAudio(stateSnapshot.Speaker);
                                                     }
                                                     if (_currentDialoguePaths.Count > 0) {
                                                         _currentDialoguePaths[_currentDialoguePaths.ElementAt(_currentDialoguePaths.Count - 1).Key] = true;
                                                     }
                                                     _blockAudioGeneration = false;
                                                 }
+                                            } else if (stateSnapshot != null) {
+                                                TraceNpcTts($"Ignored talk state speaker='{stateSnapshot.Speaker}' textPresent={!string.IsNullOrEmpty(stateSnapshot.Text)} text='{PreviewText(stateSnapshot.Text)}'");
                                             } else {
                                                 if (_currentDialoguePaths.Count > 0) {
                                                     if (!_currentDialoguePaths[_currentDialoguePaths.ElementAt(_currentDialoguePaths.Count - 1).Key] &&
@@ -593,6 +607,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                                                     }
                                                 }
                                                 if (_currentSpeechObject != null && _startedNewDialogue) {
+                                                    CancelNpcVoiceRequests("talk state cleared while dialogue was active");
                                                     var otherData = this._threadSafeObjectTable.LocalPlayer.OnlineStatus;
                                                     if (otherData.Value.RowId != 15) {
                                                         _namesToRemove.Clear();
@@ -624,6 +639,43 @@ namespace RoleplayingVoiceDalamud.Voice {
                         }
                     }
                 }
+        }
+
+        private static string PreviewText(string value) {
+            if (string.IsNullOrEmpty(value)) {
+                return "";
+            }
+
+            return value.Substring(0, Math.Min(80, value.Length)).Replace("\r", " ").Replace("\n", " ");
+        }
+
+        private static void TraceNpcTts(string message) {
+            // These breadcrumbs are intentionally logged only at dialogue handoff
+            // boundaries, not every poll, so test logs show where a line was dropped.
+            Plugin.PluginLog.Information("[NPC TTS] " + message);
+        }
+
+        private void LogTalkStateIfChanged(AddonTalkState state) {
+            if (state == null) {
+                _lastLoggedTalkStateWasPresent = false;
+                return;
+            }
+
+            var speaker = state.Speaker ?? "";
+            var text = state.Text ?? "";
+            if (_lastLoggedTalkStateWasPresent &&
+                speaker == _lastLoggedTalkStateSpeaker &&
+                text == _lastLoggedTalkStateText) {
+                return;
+            }
+
+            _lastLoggedTalkStateWasPresent = true;
+            _lastLoggedTalkStateSpeaker = speaker;
+            _lastLoggedTalkStateText = text;
+
+            // Framework_Update polls frequently while the same dialogue window is
+            // visible; only log new talk states so Dalamud's shared log stays usable.
+            Plugin.PluginLog.Information($"[DEBUG] Talk state detected - Speaker: {speaker}, Text: {text.Substring(0, Math.Min(50, text.Length))}");
         }
 
         private void GetAnimationDefaults() {
@@ -762,6 +814,34 @@ namespace RoleplayingVoiceDalamud.Voice {
                 _plugin.IpcSystem?.InvokeOnTriggerAnimation(character, animationId);
             } catch (Exception e) {
                 Plugin.PluginLog.Warning(e, e.Message);
+            }
+        }
+
+        private (long Sequence, CancellationToken Token) BeginNpcVoiceRequest(string reason) {
+            lock (_npcVoiceRequestLock) {
+                // NPC dialogue is ephemeral: once a newer line arrives, any older
+                // relay response would play stale audio and should be abandoned.
+                _npcVoiceRequestCancellation.Cancel();
+                _npcVoiceRequestCancellation = new CancellationTokenSource();
+                _npcVoiceRequestSequence++;
+                TraceNpcTts($"Started request sequence={_npcVoiceRequestSequence} reason='{reason}'");
+                return (_npcVoiceRequestSequence, _npcVoiceRequestCancellation.Token);
+            }
+        }
+
+        private void CancelNpcVoiceRequests(string reason) {
+            lock (_npcVoiceRequestLock) {
+                // Closing or advancing dialogue should also release pending relay
+                // work so an unresponsive request cannot block later playback.
+                _npcVoiceRequestCancellation.Cancel();
+                _npcVoiceRequestSequence++;
+                TraceNpcTts($"Cancelled pending requests; new sequence={_npcVoiceRequestSequence} reason='{reason}'");
+            }
+        }
+
+        private bool IsCurrentNpcVoiceRequest(long sequence) {
+            lock (_npcVoiceRequestLock) {
+                return sequence == _npcVoiceRequestSequence && !_npcVoiceRequestCancellation.IsCancellationRequested;
             }
         }
         public async void TriggerEmoteTimed(ICharacter character, ushort animationId, int time = 2000) {
@@ -930,7 +1010,14 @@ namespace RoleplayingVoiceDalamud.Voice {
                         string backupVoice = voice;
                         Stopwatch downloadTimer = Stopwatch.StartNew();
                         bool foundName = false;
-                        ReportData reportData = new ReportData(npcName, StripPlayerNameFromNPCDialogue(message, _threadSafeObjectTable.LocalPlayer.Name.TextValue, ref foundName), 0, 0, true, 0, 0, 0, _clientState.TerritoryType, note);
+                        var localPlayerName = _threadSafeObjectTable.LocalPlayer?.Name.TextValue;
+                        // LocalPlayer can briefly be unavailable while zoning, logging in, or
+                        // during plugin startup. Reporting should keep the original line rather
+                        // than dropping NPC playback with a NullReferenceException.
+                        var reportMessage = !string.IsNullOrWhiteSpace(localPlayerName)
+                            ? StripPlayerNameFromNPCDialogue(message, localPlayerName, ref foundName)
+                            : message;
+                        ReportData reportData = new ReportData(npcName, reportMessage, 0, 0, true, 0, 0, 0, _clientState.TerritoryType, note);
                         string npcData = JsonConvert.SerializeObject(reportData);
                         MemoryStream stream = new MemoryStream();
                         bool canProceed = false;
@@ -941,9 +1028,17 @@ namespace RoleplayingVoiceDalamud.Voice {
                         unsafe {
                             canBeMuted = Conditions.Instance()->BoundByDuty && !IsInACutscene();
                         }
+                        var request = !onlySendData && _plugin.Window.NpcSpeechEnabled
+                            ? BeginNpcVoiceRequest($"npc='{nameToUse}' explicit voice path")
+                            : (Sequence: 0L, Token: CancellationToken.None);
                         var values =
                         await _plugin.NpcVoiceManager.GetCharacterAudio(stream, message, message, message, nameToUse, gender, backupVoice, false,
-                        voiceModel, npcData, false, false, canProceed, !_plugin.Window.NpcSpeechEnabled ? VoiceLinePriority.Datamining : voiceLinePriority);
+                        voiceModel, npcData, false, false, canProceed, !_plugin.Window.NpcSpeechEnabled ? VoiceLinePriority.Datamining : voiceLinePriority,
+                        cancellationToken: request.Token);
+                        if (request.Sequence != 0 && !IsCurrentNpcVoiceRequest(request.Sequence)) {
+                            stream.Dispose();
+                            return;
+                        }
                         if (!previouslyAddedLines.Contains(message + nameToUse) && _plugin.Window.NpcSpeechEnabled) {
                             _npcVoiceHistoryItems.Add(new NPCVoiceHistoryItem(message, message, message, nameToUse, gender, backupVoice, false, true, npcData, false, canBeMuted, values.Item2));
                             previouslyAddedLines.Add(message + nameToUse);
@@ -1006,6 +1101,9 @@ namespace RoleplayingVoiceDalamud.Voice {
                             }
                         }
                     }
+                } catch (OperationCanceledException) {
+                    // A newer dialogue line replaced this request; dropping it keeps
+                    // old relay responses from speaking over the current line.
                 } catch (Exception e) {
                     Plugin.PluginLog.Warning(e, e.Message);
                     if (_plugin.Config.DebugMode) {
@@ -1020,8 +1118,18 @@ namespace RoleplayingVoiceDalamud.Voice {
         }
         private async void NPCText(string npcName, string message, bool ignoreAutoProgress, NPCVoiceManager.VoiceModel voiceModel,
             bool lowLatencyMode = false, bool redoLine = false, string note = "", VoiceLinePriority voiceLinePriority = VoiceLinePriority.None) {
-            if (VerifyIsEnglish(message) && !message.Contains("You have submitted")) {
-                try {
+            if (!VerifyIsEnglish(message)) {
+                TraceNpcTts($"NPCText skipped non-English/preflight text npc='{npcName}' text='{PreviewText(message)}'");
+                return;
+            }
+
+            if (message.Contains("You have submitted")) {
+                TraceNpcTts($"NPCText skipped submitted-objective text npc='{npcName}' text='{PreviewText(message)}'");
+                return;
+            }
+
+            try {
+                    TraceNpcTts($"NPCText entered npc='{npcName}' lowLatency={lowLatencyMode} redo={redoLine} priority={voiceLinePriority} block={_blockAudioGeneration} enabled={_plugin.Window.NpcSpeechEnabled} text='{PreviewText(message)}'");
                     bool gender = false;
                     byte race = 0;
                     int body = 0;
@@ -1038,6 +1146,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                         string value = FeoUlRetainerCleanup(nameToUse, StripPlayerNameFromNPCDialogue(initialCleanedValue, _threadSafeObjectTable.LocalPlayer.Name.TextValue, ref foundName));
                         string arcValue = FeoUlRetainerCleanup(nameToUse, StripPlayerNameFromNPCDialogueArc(message));
                         string backupVoice = PickVoiceBasedOnTraits(nameToUse, gender, race, body, ref isExtra, ref isTerritorySpecific);
+                        TraceNpcTts($"NPCText prepared npc='{nameToUse}' discoveredObject={npcObject != null} retainer={isRetainer} gender={gender} race={race} body={body} backupVoice='{backupVoice}' extra={isExtra} territorySpecific={isTerritorySpecific} text='{PreviewText(value)}'");
                         ReportData reportData = new ReportData(npcName, value, npcObject, _clientState.TerritoryType, note);
                         string npcData = JsonConvert.SerializeObject(reportData);
                         Stopwatch downloadTimer = Stopwatch.StartNew();
@@ -1052,11 +1161,17 @@ namespace RoleplayingVoiceDalamud.Voice {
                         unsafe {
                             useMuteList = (Conditions.Instance()->BoundByDuty && !IsInACutscene());
                         }
+                        var request = BeginNpcVoiceRequest($"npc='{nameToUse}' talk addon path");
                         for (int i = 0; i < 2; i++) {
                             MemoryStream stream = new MemoryStream();
-                            var values =
-                            await _plugin.NpcVoiceManager.GetCharacterAudio(stream, value, arcValue, initialCleanedValue, nameToUse, gender, backupVoice, false, voiceModel, npcData, redoLine,
-                            false, useMuteList, conditionsForDatamining);
+	                            var values =
+	                            await _plugin.NpcVoiceManager.GetCharacterAudio(stream, value, arcValue, initialCleanedValue, nameToUse, gender, backupVoice, false, voiceModel, npcData, redoLine,
+	                            false, useMuteList, conditionsForDatamining, cancellationToken: request.Token);
+	                            if (!IsCurrentNpcVoiceRequest(request.Sequence)) {
+	                                TraceNpcTts($"Dropping stale audio response sequence={request.Sequence} npc='{nameToUse}' text='{PreviewText(value)}'");
+	                                stream.Dispose();
+	                                return;
+	                            }
                             if (!previouslyAddedLines.Contains(value + nameToUse) && _plugin.Window.NpcSpeechEnabled) {
                                 unsafe {
                                     _npcVoiceHistoryItems.Add(new NPCVoiceHistoryItem(value, arcValue, initialCleanedValue, nameToUse, gender, backupVoice, false,
@@ -1067,10 +1182,11 @@ namespace RoleplayingVoiceDalamud.Voice {
                                     _npcVoiceHistoryItems.RemoveAt(0);
                                 }
                             }
-                            if (stream != null && stream.Length > 1 && _plugin.Window.NpcSpeechEnabled) {
-                                if (_plugin.Config.DebugMode) {
-                                    _plugin.Chat.Print("Stream is valid! Download took " + downloadTimer.Elapsed.ToString());
-                                }
+	                            if (stream != null && stream.Length > 1 && _plugin.Window.NpcSpeechEnabled) {
+	                                TraceNpcTts($"Audio stream ready sequence={request.Sequence} npc='{nameToUse}' engine='{values.Item2}' length={stream.Length}");
+	                                if (_plugin.Config.DebugMode) {
+	                                    _plugin.Chat.Print("Stream is valid! Download took " + downloadTimer.Elapsed.ToString());
+	                                }
                                 WaveStream wavePlayer = _plugin.NpcVoiceManager.StreamToFoundationReader(stream);
                                 ActorMemory actorMemory = null;
                                 AnimationMemory animationMemory = null;
@@ -1110,10 +1226,11 @@ namespace RoleplayingVoiceDalamud.Voice {
                                     if (_plugin.Config.DebugMode) {
                                         _plugin.Chat.Print($"Audio: {wavePlayer.WaveFormat.SampleRate}Hz {wavePlayer.WaveFormat.Channels}ch, pitch={pitch:F3}, speed={_plugin.Config.NPCSpeechSpeed:F2}, engine={values.Item2}, smb={useSmbPitch}");
                                     }
-                                    unsafe {
-                                        if (!_blockAudioGeneration) {
-                                            _plugin.MediaManager.PlayAudioStream(_currentSpeechObject, wavePlayer, SoundType.NPC,
-                                           (IsInACutscene() && Conditions.Instance()->BoundByDuty), useSmbPitch, pitch, 0,
+	                                    unsafe {
+	                                        if (!_blockAudioGeneration) {
+		                                            TraceNpcTts($"Playing audio sequence={request.Sequence} npc='{nameToUse}' engine='{values.Item2}' pitch={pitch:F3} speed={_plugin.Config.NPCSpeechSpeed:F2}");
+	                                            _plugin.MediaManager.PlayAudioStream(_currentSpeechObject, wavePlayer, SoundType.NPC,
+	                                           (IsInACutscene() && Conditions.Instance()->BoundByDuty), useSmbPitch, pitch, 0,
                                             IsInACutscene() || lowLatencyMode, delegate (object obj, string value) {
                                                 if (_hook != null) {
                                                     try {
@@ -1198,32 +1315,41 @@ namespace RoleplayingVoiceDalamud.Voice {
                                                         }
                                                     }
                                                 }
-                                            }, _plugin.Config.NPCSpeechSpeed, values.Item2 == "Elevenlabs" ? 0.5f : (values.Item2 == "XTTS" ? 1.8f : 1.8f));
-                                        }
-                                    }
+	                                            }, _plugin.Config.NPCSpeechSpeed, values.Item2 == "Elevenlabs" ? 0.5f : (values.Item2 == "XTTS" ? 1.8f : 1.8f));
+	                                        } else {
+		                                            TraceNpcTts($"Audio ready but playback suppressed by blockAudioGeneration sequence={request.Sequence} npc='{nameToUse}' text='{PreviewText(value)}'");
+	                                        }
+	                                    }
                                     break;
                                 } else {
                                     if (_plugin.Config.DebugMode) {
                                         _plugin.Chat.Print("Waveplayer failed, trying again." + downloadTimer.Elapsed.ToString());
                                     }
                                 }
-                            } else {
-                                if (_plugin.Config.DebugMode) {
-                                    _plugin.Chat.Print("Stream was null! trying again. " + downloadTimer.Elapsed.ToString());
-                                }
-                                if (_plugin.Window.NpcSpeechEnabled) {
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                } catch (Exception e) {
-                    Plugin.PluginLog.Warning(e, e.Message);
-                    if (_plugin.Config.DebugMode) {
-                        _plugin.Chat.Print(e.Message);
-                    }
-                }
-            }
+	                            } else {
+	                                TraceNpcTts($"Audio stream unavailable or NPC speech disabled npc='{nameToUse}' enabled={_plugin.Window.NpcSpeechEnabled} streamLength={(stream == null ? -1 : stream.Length)} text='{PreviewText(value)}'");
+	                                if (_plugin.Config.DebugMode) {
+	                                    _plugin.Chat.Print("Stream was null! trying again. " + downloadTimer.Elapsed.ToString());
+	                                }
+		                                if (_plugin.Window.NpcSpeechEnabled) {
+		                                    break;
+		                                }
+		                            }
+		                        }
+			                    } else {
+			                        TraceNpcTts($"NPCText skipped retainer npc='{npcName}' dontVoiceRetainers={_plugin.Config.DontVoiceRetainers}");
+			                    }
+	                } catch (OperationCanceledException) {
+	                    TraceNpcTts($"NPCText cancelled npc='{npcName}' text='{PreviewText(message)}'");
+	                    // A newer dialogue line replaced this request; dropping it keeps
+	                    // old relay responses from speaking over the current line.
+	                } catch (Exception e) {
+	                    TraceNpcTts($"NPCText exception npc='{npcName}' type={e.GetType().Name} message='{e.Message}' text='{PreviewText(message)}'");
+	                    Plugin.PluginLog.Warning(e, e.Message);
+	                    if (_plugin.Config.DebugMode) {
+	                        _plugin.Chat.Print(e.Message);
+	                    }
+	                }
         }
 
         public WaveStream GetWavePlayer(string npcName, Stream stream, ReportData reportData) {
@@ -1279,8 +1405,13 @@ namespace RoleplayingVoiceDalamud.Voice {
                     unsafe {
                         canBeMuted = (Conditions.Instance()->BoundByDuty && !IsInACutscene());
                     }
+                    var request = BeginNpcVoiceRequest($"npc='{nameToUse}' object/bubble path");
                     var values =
-                    await _plugin.NpcVoiceManager.GetCharacterAudio(stream, value, StripPlayerNameFromNPCDialogueArc(message), initialConvertedString, nameToUse, gender, voice, false, voiceModel, npcData, false, false, canBeMuted, conditionsForDatamining);
+                    await _plugin.NpcVoiceManager.GetCharacterAudio(stream, value, StripPlayerNameFromNPCDialogueArc(message), initialConvertedString, nameToUse, gender, voice, false, voiceModel, npcData, false, false, canBeMuted, conditionsForDatamining, cancellationToken: request.Token);
+	                    if (!IsCurrentNpcVoiceRequest(request.Sequence)) {
+	                        stream.Dispose();
+	                        return;
+	                    }
                     if (stream != null && _plugin.Window.NpcSpeechEnabled) {
                         WaveStream wavePlayer = _plugin.NpcVoiceManager.StreamToFoundationReader(stream);
                         bool useSmbPitch = CheckIfshouldUseSmbPitch(nameToUse, body);
@@ -1293,6 +1424,9 @@ namespace RoleplayingVoiceDalamud.Voice {
                         }
                     } else {
                     }
+                } catch (OperationCanceledException) {
+                    // A newer dialogue line replaced this request; dropping it keeps
+                    // old relay responses from speaking over the current line.
                 } catch {
                 }
             }
@@ -1739,6 +1873,8 @@ namespace RoleplayingVoiceDalamud.Voice {
             _clientState.TerritoryChanged -= _clientState_TerritoryChanged;
             _toast.Toast -= _toast_Toast;
             disposed = true;
+            CancelNpcVoiceRequests("handler disposed");
+            _npcVoiceRequestCancellation.Dispose();
 
             _memoryService.Shutdown();
             _settingService.Shutdown();

--- a/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
+++ b/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
@@ -86,9 +86,6 @@ namespace RoleplayingVoiceDalamud.Voice {
         private string _lastSoundPath;
         bool _blockNpcChat = false;
         private List<NPCVoiceHistoryItem> _npcVoiceHistoryItems = new List<NPCVoiceHistoryItem>();
-        private bool _lastLoggedTalkStateWasPresent;
-        private string _lastLoggedTalkStateSpeaker = "";
-        private string _lastLoggedTalkStateText = "";
 
         ////public List<ActionTimeline> LipSyncTypes { get; private set; }
 
@@ -351,14 +348,14 @@ namespace RoleplayingVoiceDalamud.Voice {
                                             Thread.Sleep(1000);
                                             _blockAudioGenerationCount--;
                                         });
-	                                    }
-	                                    _blockAudioGeneration = e.isBlocking;
-	                                    _lastNPCAnnouncementName = null;
-	                                    _currentDialoguePaths[e.SoundPath] = false;
-	                                    TraceNpcTts($"Cutscene audio filter changed block={e.isBlocking} blockCount={_blockAudioGenerationCount} sound='{e.SoundPath}'");
-	                                    if (_plugin.Config.DebugMode) {
-	                                        if (_lastNPCAnnouncementName != null) {
-	                                            DumpCurrentAudio(_lastNPCAnnouncementName);
+                                    }
+                                    _blockAudioGeneration = e.isBlocking;
+                                    _lastNPCAnnouncementName = null;
+                                    _currentDialoguePaths[e.SoundPath] = false;
+                                    TraceNpcTts($"Cutscene audio filter changed block={e.isBlocking} blockCount={_blockAudioGenerationCount} sound='{e.SoundPath}'");
+                                    if (_plugin.Config.DebugMode) {
+                                        if (_lastNPCAnnouncementName != null) {
+                                            DumpCurrentAudio(_lastNPCAnnouncementName);
                                         }
                                         _plugin.Chat.Print("Block Next Line Of Dialogue Is " + e.isBlocking);
                                         _plugin.Chat.Print("Dialogue block created by " + e.SoundPath);
@@ -545,9 +542,11 @@ namespace RoleplayingVoiceDalamud.Voice {
                                         if (_state == null) {
                                             _state = GetBattleTalkAddonState();
                                         }
-                                        var stateSnapshot = _state;
-                                        LogTalkStateIfChanged(stateSnapshot);
+                                        if (_state != null) {
+                                            Plugin.PluginLog.Information($"[DEBUG] Talk state detected - Speaker: {_state.Speaker}, Text: {_state.Text?.Substring(0, Math.Min(50, _state.Text?.Length ?? 0))}");
+                                        }
                                         Task.Run((Action)delegate {
+                                            var stateSnapshot = _state;
                                             if (!_alreadySortingList) {
                                                 _alreadySortingList = true;
                                                 _sortedObjectTable = _threadSafeObjectTable.ToList();
@@ -653,29 +652,6 @@ namespace RoleplayingVoiceDalamud.Voice {
             // These breadcrumbs are intentionally logged only at dialogue handoff
             // boundaries, not every poll, so test logs show where a line was dropped.
             Plugin.PluginLog.Information("[NPC TTS] " + message);
-        }
-
-        private void LogTalkStateIfChanged(AddonTalkState state) {
-            if (state == null) {
-                _lastLoggedTalkStateWasPresent = false;
-                return;
-            }
-
-            var speaker = state.Speaker ?? "";
-            var text = state.Text ?? "";
-            if (_lastLoggedTalkStateWasPresent &&
-                speaker == _lastLoggedTalkStateSpeaker &&
-                text == _lastLoggedTalkStateText) {
-                return;
-            }
-
-            _lastLoggedTalkStateWasPresent = true;
-            _lastLoggedTalkStateSpeaker = speaker;
-            _lastLoggedTalkStateText = text;
-
-            // Framework_Update polls frequently while the same dialogue window is
-            // visible; only log new talk states so Dalamud's shared log stays usable.
-            Plugin.PluginLog.Information($"[DEBUG] Talk state detected - Speaker: {speaker}, Text: {text.Substring(0, Math.Min(50, text.Length))}");
         }
 
         private void GetAnimationDefaults() {
@@ -1164,14 +1140,14 @@ namespace RoleplayingVoiceDalamud.Voice {
                         var request = BeginNpcVoiceRequest($"npc='{nameToUse}' talk addon path");
                         for (int i = 0; i < 2; i++) {
                             MemoryStream stream = new MemoryStream();
-	                            var values =
-	                            await _plugin.NpcVoiceManager.GetCharacterAudio(stream, value, arcValue, initialCleanedValue, nameToUse, gender, backupVoice, false, voiceModel, npcData, redoLine,
-	                            false, useMuteList, conditionsForDatamining, cancellationToken: request.Token);
-	                            if (!IsCurrentNpcVoiceRequest(request.Sequence)) {
-	                                TraceNpcTts($"Dropping stale audio response sequence={request.Sequence} npc='{nameToUse}' text='{PreviewText(value)}'");
-	                                stream.Dispose();
-	                                return;
-	                            }
+                            var values =
+                            await _plugin.NpcVoiceManager.GetCharacterAudio(stream, value, arcValue, initialCleanedValue, nameToUse, gender, backupVoice, false, voiceModel, npcData, redoLine,
+                            false, useMuteList, conditionsForDatamining, cancellationToken: request.Token);
+                            if (!IsCurrentNpcVoiceRequest(request.Sequence)) {
+                                TraceNpcTts($"Dropping stale audio response sequence={request.Sequence} npc='{nameToUse}' text='{PreviewText(value)}'");
+                                stream.Dispose();
+                                return;
+                            }
                             if (!previouslyAddedLines.Contains(value + nameToUse) && _plugin.Window.NpcSpeechEnabled) {
                                 unsafe {
                                     _npcVoiceHistoryItems.Add(new NPCVoiceHistoryItem(value, arcValue, initialCleanedValue, nameToUse, gender, backupVoice, false,
@@ -1182,11 +1158,11 @@ namespace RoleplayingVoiceDalamud.Voice {
                                     _npcVoiceHistoryItems.RemoveAt(0);
                                 }
                             }
-	                            if (stream != null && stream.Length > 1 && _plugin.Window.NpcSpeechEnabled) {
-	                                TraceNpcTts($"Audio stream ready sequence={request.Sequence} npc='{nameToUse}' engine='{values.Item2}' length={stream.Length}");
-	                                if (_plugin.Config.DebugMode) {
-	                                    _plugin.Chat.Print("Stream is valid! Download took " + downloadTimer.Elapsed.ToString());
-	                                }
+                            if (stream != null && stream.Length > 1 && _plugin.Window.NpcSpeechEnabled) {
+                                TraceNpcTts($"Audio stream ready sequence={request.Sequence} npc='{nameToUse}' engine='{values.Item2}' length={stream.Length}");
+                                if (_plugin.Config.DebugMode) {
+                                    _plugin.Chat.Print("Stream is valid! Download took " + downloadTimer.Elapsed.ToString());
+                                }
                                 WaveStream wavePlayer = _plugin.NpcVoiceManager.StreamToFoundationReader(stream);
                                 ActorMemory actorMemory = null;
                                 AnimationMemory animationMemory = null;
@@ -1226,11 +1202,11 @@ namespace RoleplayingVoiceDalamud.Voice {
                                     if (_plugin.Config.DebugMode) {
                                         _plugin.Chat.Print($"Audio: {wavePlayer.WaveFormat.SampleRate}Hz {wavePlayer.WaveFormat.Channels}ch, pitch={pitch:F3}, speed={_plugin.Config.NPCSpeechSpeed:F2}, engine={values.Item2}, smb={useSmbPitch}");
                                     }
-	                                    unsafe {
-	                                        if (!_blockAudioGeneration) {
-		                                            TraceNpcTts($"Playing audio sequence={request.Sequence} npc='{nameToUse}' engine='{values.Item2}' pitch={pitch:F3} speed={_plugin.Config.NPCSpeechSpeed:F2}");
-	                                            _plugin.MediaManager.PlayAudioStream(_currentSpeechObject, wavePlayer, SoundType.NPC,
-	                                           (IsInACutscene() && Conditions.Instance()->BoundByDuty), useSmbPitch, pitch, 0,
+                                    unsafe {
+                                        if (!_blockAudioGeneration) {
+                                            TraceNpcTts($"Playing audio sequence={request.Sequence} npc='{nameToUse}' engine='{values.Item2}' pitch={pitch:F3} speed={_plugin.Config.NPCSpeechSpeed:F2}");
+                                            _plugin.MediaManager.PlayAudioStream(_currentSpeechObject, wavePlayer, SoundType.NPC,
+                                           (IsInACutscene() && Conditions.Instance()->BoundByDuty), useSmbPitch, pitch, 0,
                                             IsInACutscene() || lowLatencyMode, delegate (object obj, string value) {
                                                 if (_hook != null) {
                                                     try {
@@ -1315,41 +1291,41 @@ namespace RoleplayingVoiceDalamud.Voice {
                                                         }
                                                     }
                                                 }
-	                                            }, _plugin.Config.NPCSpeechSpeed, values.Item2 == "Elevenlabs" ? 0.5f : (values.Item2 == "XTTS" ? 1.8f : 1.8f));
-	                                        } else {
-		                                            TraceNpcTts($"Audio ready but playback suppressed by blockAudioGeneration sequence={request.Sequence} npc='{nameToUse}' text='{PreviewText(value)}'");
-	                                        }
-	                                    }
+                                            }, _plugin.Config.NPCSpeechSpeed, values.Item2 == "Elevenlabs" ? 0.5f : (values.Item2 == "XTTS" ? 1.8f : 1.8f));
+                                        } else {
+                                            TraceNpcTts($"Audio ready but playback suppressed by blockAudioGeneration sequence={request.Sequence} npc='{nameToUse}' text='{PreviewText(value)}'");
+                                        }
+                                    }
                                     break;
                                 } else {
                                     if (_plugin.Config.DebugMode) {
                                         _plugin.Chat.Print("Waveplayer failed, trying again." + downloadTimer.Elapsed.ToString());
                                     }
                                 }
-	                            } else {
-	                                TraceNpcTts($"Audio stream unavailable or NPC speech disabled npc='{nameToUse}' enabled={_plugin.Window.NpcSpeechEnabled} streamLength={(stream == null ? -1 : stream.Length)} text='{PreviewText(value)}'");
-	                                if (_plugin.Config.DebugMode) {
-	                                    _plugin.Chat.Print("Stream was null! trying again. " + downloadTimer.Elapsed.ToString());
-	                                }
-		                                if (_plugin.Window.NpcSpeechEnabled) {
-		                                    break;
-		                                }
-		                            }
-		                        }
-			                    } else {
-			                        TraceNpcTts($"NPCText skipped retainer npc='{npcName}' dontVoiceRetainers={_plugin.Config.DontVoiceRetainers}");
-			                    }
-	                } catch (OperationCanceledException) {
-	                    TraceNpcTts($"NPCText cancelled npc='{npcName}' text='{PreviewText(message)}'");
-	                    // A newer dialogue line replaced this request; dropping it keeps
-	                    // old relay responses from speaking over the current line.
-	                } catch (Exception e) {
-	                    TraceNpcTts($"NPCText exception npc='{npcName}' type={e.GetType().Name} message='{e.Message}' text='{PreviewText(message)}'");
-	                    Plugin.PluginLog.Warning(e, e.Message);
-	                    if (_plugin.Config.DebugMode) {
-	                        _plugin.Chat.Print(e.Message);
-	                    }
-	                }
+                            } else {
+                                TraceNpcTts($"Audio stream unavailable or NPC speech disabled npc='{nameToUse}' enabled={_plugin.Window.NpcSpeechEnabled} streamLength={(stream == null ? -1 : stream.Length)} text='{PreviewText(value)}'");
+                                if (_plugin.Config.DebugMode) {
+                                    _plugin.Chat.Print("Stream was null! trying again. " + downloadTimer.Elapsed.ToString());
+                                }
+                                if (_plugin.Window.NpcSpeechEnabled) {
+                                    break;
+                                }
+                            }
+                        }
+                    } else {
+                        TraceNpcTts($"NPCText skipped retainer npc='{npcName}' dontVoiceRetainers={_plugin.Config.DontVoiceRetainers}");
+                    }
+            } catch (OperationCanceledException) {
+                TraceNpcTts($"NPCText cancelled npc='{npcName}' text='{PreviewText(message)}'");
+                // A newer dialogue line replaced this request; dropping it keeps
+                // old relay responses from speaking over the current line.
+            } catch (Exception e) {
+                TraceNpcTts($"NPCText exception npc='{npcName}' type={e.GetType().Name} message='{e.Message}' text='{PreviewText(message)}'");
+                Plugin.PluginLog.Warning(e, e.Message);
+                if (_plugin.Config.DebugMode) {
+                    _plugin.Chat.Print(e.Message);
+                }
+            }
         }
 
         public WaveStream GetWavePlayer(string npcName, Stream stream, ReportData reportData) {


### PR DESCRIPTION
Intent: prevent stale NPC TTS from playing after dialogue advances, while adding targeted diagnostics for the NPC playback path.

- Add a sequence-based cancellation guard for NPC voice requests.
- Cancel pending NPC TTS work when the talk text changes, the talk state clears, or the handler is disposed.
- Pass cancellation tokens into RoleplayingVoiceCore.GetCharacterAudio so abandoned relay requests can be stopped.
- Drop late audio responses when a newer dialogue line has already replaced them.
- Add targeted [NPC TTS] breadcrumbs at dialogue handoff, request start/cancel, stream-ready, playback, and suppression points.
- Guard NPC report text generation when LocalPlayer is briefly unavailable during startup/zoning.
- Update the RoleplayingVoiceCore submodule pointer to the matching relay-resilience Core changes: https://github.com/Sebane1/RoleplayingVoiceCore/pull/7