### PR TITLE
Handle leak disposal

### DIFF
--- a/ArtemisRoleplayingKit/CoreLogic/ConfigurationSetup.cs
+++ b/ArtemisRoleplayingKit/CoreLogic/ConfigurationSetup.cs
@@ -142,7 +142,9 @@ namespace RoleplayingVoice {
                 Window.OnMoveFailed += Window_OnMoveFailed;
                 config.OnConfigurationChanged += Config_OnConfigurationChanged;
                 _emoteReaderHook = new EmoteReaderHooks(_interopProvider, _clientState, _threadSafeObjectTable);
-                _emoteReaderHook.OnEmote += (instigator, emoteId) => OnEmote(instigator as ICharacter, emoteId);
+                // Keep the delegate instance so teardown can unsubscribe the same handler before disposing the hook.
+                _onEmoteHandler = (instigator, emoteId) => OnEmote(instigator as ICharacter, emoteId);
+                _emoteReaderHook.OnEmote += _onEmoteHandler;
                 _realChat = new Chat(_sigScanner);
                 RaceVoice.LoadRacialVoiceInfo();
                 CheckDependancies();

--- a/ArtemisRoleplayingKit/CoreLogic/ConfigurationSetup.cs
+++ b/ArtemisRoleplayingKit/CoreLogic/ConfigurationSetup.cs
@@ -129,6 +129,7 @@ namespace RoleplayingVoice {
                     new PenumbraAndGlamourerIpcWrapper(pluginInterface);
                     Penumbra.Api.IpcSubscribers.ModSettingChanged.Subscriber(pluginInterface).Event += modSettingChanged;
                     Penumbra.Api.IpcSubscribers.GameObjectRedrawn.Subscriber(pluginInterface).Event += gameObjectRedrawn;
+                    _penumbraEventSubscriptionsActive = true;
                     Plugin.PluginLog.Debug("Penumbra connected to Artemis Roleplaying Kit");
                     _penumbraReady = true;
                 } catch (Exception e) {

--- a/ArtemisRoleplayingKit/Plugin.cs
+++ b/ArtemisRoleplayingKit/Plugin.cs
@@ -89,6 +89,7 @@ namespace RoleplayingVoice
         private Stopwatch _queueTimer = new Stopwatch();
 
         private EmoteReaderHooks _emoteReaderHook;
+        private Action<IGameObject, ushort> _onEmoteHandler;
         private Chat _realChat;
         private Filter _filter;
         private MediaGameObject _playerObject;
@@ -715,76 +716,119 @@ namespace RoleplayingVoice
         }
         #endregion
         #region IDisposable Support
-        protected virtual void Dispose(bool disposing)
+        private void RunDisposeStep(string cleanupName, System.Action cleanup)
         {
             try
             {
-                disposed = true;
-                Disposed = true;
-                config.Save();
-                config.OnConfigurationChanged -= Config_OnConfigurationChanged;
-                IpcSystem.Dispose();
-                _chat.ChatMessage -= Chat_ChatMessage;
-                this.pluginInterface.UiBuilder.Draw -= UiBuilder_Draw;
-                this.pluginInterface.UiBuilder.OpenConfigUi -= UiBuilder_OpenConfigUi;
-                this.windowSystem.RemoveAllWindows();
-                this.commandManager?.Dispose();
-                if (_filter != null)
-                {
-                    _filter.OnSoundIntercepted -= _filter_OnSoundIntercepted;
-                }
-                try
-                {
-                    if (_mediaManager != null)
-                    {
-                        _mediaManager.Invalidated = true;
-                        _mediaManager.OnErrorReceived -= _mediaManager_OnErrorReceived;
-                        _mediaManager?.Dispose();
-                    }
-                } catch (Exception e)
-                {
-                    Plugin.PluginLog?.Warning(e, e.Message);
-                }
-                try
-                {
-                    _clientState.Login -= _clientState_Login;
-                    _clientState.Logout -= _clientState_Logout;
-                    _clientState.TerritoryChanged -= _clientState_TerritoryChanged;
-                    _clientState.LeavePvP -= _clientState_LeavePvP;
-                } catch (Exception e)
-                {
-                    Plugin.PluginLog?.Warning(e, e.Message);
-                }
-                try
-                {
-                    _toast.ErrorToast -= _toast_ErrorToast;
-                } catch (Exception e)
-                {
-                    Plugin.PluginLog?.Warning(e, e.Message);
-                }
-                try
-                {
-                    _framework.Update -= framework_Update;
-                } catch (Exception e)
-                {
-                    Plugin.PluginLog?.Warning(e, e.Message);
-                }
-                _networkedClient?.Dispose();
-                Filter?.Dispose();
-                if (_emoteReaderHook != null)
-                {
-                    if (_emoteReaderHook.OnEmote != null)
-                    {
-                        _emoteReaderHook.OnEmote -= (instigator, emoteId) => OnEmote(instigator as ICharacter, emoteId);
-                    }
-                }
-                CleanupEmoteWatchList();
-                _addonTalkHandler?.Dispose();
-                //PenumbraAndGlamourerIPCWrapper.Instance.ModSettingChanged.Event -= modSettingChanged;
+                cleanup();
             } catch (Exception e)
             {
-                Plugin.PluginLog?.Warning(e, e.Message);
+                Plugin.PluginLog?.Warning(e, $"[Artemis Roleplaying Kit] {cleanupName} cleanup failed: {e.Message}");
             }
+        }
+
+        private void DisposeHookResources()
+        {
+            // Hook cleanup is kept separate from unrelated teardown so one failing cleanup step cannot leak hooks.
+            RunDisposeStep("ActionEffectHandler hook", () =>
+            {
+                if (_actionEffectListener == null)
+                {
+                    return;
+                }
+
+                _actionEffectListener.OnActionEffectReceived -= ActionEffectListener_OnActionEffectReceived;
+                _actionEffectListener.Dispose();
+                _actionEffectListener = null;
+                Plugin.PluginLog?.Information("[Artemis Roleplaying Kit] Disposed ActionEffectHandler hook.");
+            });
+
+            RunDisposeStep("emote reader hook", () =>
+            {
+                if (_emoteReaderHook == null)
+                {
+                    return;
+                }
+
+                if (_onEmoteHandler != null)
+                {
+                    _emoteReaderHook.OnEmote -= _onEmoteHandler;
+                }
+
+                _emoteReaderHook.Dispose();
+                _emoteReaderHook = null;
+                _onEmoteHandler = null;
+                Plugin.PluginLog?.Information("[Artemis Roleplaying Kit] Disposed emote reader hook.");
+            });
+
+            RunDisposeStep("sound filter hooks", () =>
+            {
+                if (_filter == null)
+                {
+                    return;
+                }
+
+                _filter.OnSoundIntercepted -= _filter_OnSoundIntercepted;
+                _filter.Dispose();
+                _filter = null;
+                Plugin.PluginLog?.Information("[Artemis Roleplaying Kit] Disposed sound filter hooks.");
+            });
+
+            RunDisposeStep("addon talk handler hooks", () =>
+            {
+                if (_addonTalkHandler == null)
+                {
+                    return;
+                }
+
+                _addonTalkHandler.Dispose();
+                _addonTalkHandler = null;
+                Plugin.PluginLog?.Information("[Artemis Roleplaying Kit] Disposed addon talk handler hooks.");
+            });
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            Disposed = true;
+
+            RunDisposeStep("configuration save", () => config.Save());
+            RunDisposeStep("configuration event", () => config.OnConfigurationChanged -= Config_OnConfigurationChanged);
+            RunDisposeStep("IPC", () => _ipcSystem?.Dispose());
+            RunDisposeStep("chat event", () => _chat.ChatMessage -= Chat_ChatMessage);
+            RunDisposeStep("UiBuilder draw event", () => this.pluginInterface.UiBuilder.Draw -= UiBuilder_Draw);
+            RunDisposeStep("UiBuilder config event", () => this.pluginInterface.UiBuilder.OpenConfigUi -= UiBuilder_OpenConfigUi);
+            RunDisposeStep("window system", () => this.windowSystem.RemoveAllWindows());
+            RunDisposeStep("command manager", () => this.commandManager?.Dispose());
+            RunDisposeStep("media manager", () =>
+            {
+                if (_mediaManager != null)
+                {
+                    _mediaManager.Invalidated = true;
+                    _mediaManager.OnErrorReceived -= _mediaManager_OnErrorReceived;
+                    _mediaManager.Dispose();
+                    _mediaManager = null;
+                }
+            });
+            RunDisposeStep("client state events", () =>
+            {
+                _clientState.Login -= _clientState_Login;
+                _clientState.Logout -= _clientState_Logout;
+                _clientState.TerritoryChanged -= _clientState_TerritoryChanged;
+                _clientState.LeavePvP -= _clientState_LeavePvP;
+            });
+            RunDisposeStep("toast event", () => _toast.ErrorToast -= _toast_ErrorToast);
+            RunDisposeStep("framework update event", () => _framework.Update -= framework_Update);
+            RunDisposeStep("networked client", () => _networkedClient?.Dispose());
+            RunDisposeStep("plugin window hooks", () => Window?.DisposeHookResources());
+            DisposeHookResources();
+            RunDisposeStep("emote watch list", CleanupEmoteWatchList);
+            //PenumbraAndGlamourerIPCWrapper.Instance.ModSettingChanged.Event -= modSettingChanged;
         }
 
         public void Dispose()

--- a/ArtemisRoleplayingKit/Plugin.cs
+++ b/ArtemisRoleplayingKit/Plugin.cs
@@ -448,6 +448,7 @@ namespace RoleplayingVoice
                     {
                         ipcSystem?.Dispose();
                         addonTalkHandler?.Dispose();
+                        // AddonTalkHandler owns addonTalkManager after construction; dispose the manager directly only if handler creation failed.
                         if (addonTalkHandler == null)
                         {
                             addonTalkManager?.Dispose();
@@ -878,6 +879,7 @@ namespace RoleplayingVoice
             });
             RunDisposeStep("Penumbra IPC events", () =>
             {
+                // Penumbra is optional, so only unsubscribe if startup confirmed that both IPC event subscriptions succeeded.
                 if (!_penumbraEventSubscriptionsActive)
                 {
                     return;

--- a/ArtemisRoleplayingKit/Plugin.cs
+++ b/ArtemisRoleplayingKit/Plugin.cs
@@ -119,6 +119,8 @@ namespace RoleplayingVoice
         private bool streamWasPlaying;
         private bool _inGameSoundStartedAudio;
         private bool _penumbraReady = true;
+        private bool _penumbraEventSubscriptionsActive;
+        private readonly object _disposeLock = new object();
         private string lastPrintedWarning;
         private string stagingPath;
         private string potentialStream;
@@ -394,22 +396,63 @@ namespace RoleplayingVoice
 
                 Task.Run(async () =>
                 {
+                    AddonTalkManager addonTalkManager = null;
+                    AddonTalkHandler addonTalkHandler = null;
+                    IpcSystem ipcSystem = null;
                     try
                     {
-                        _npcVoiceManager = new NPCVoiceManager(await NPCVoiceMapping.GetVoiceMappings(), await NPCVoiceMapping.GetCharacterToCacheType(),
+                        var voiceMappings = await NPCVoiceMapping.GetVoiceMappings();
+                        var cacheTypes = await NPCVoiceMapping.GetCharacterToCacheType();
+
+                        lock (_disposeLock)
+                        {
+                            if (disposed)
+                            {
+                                return;
+                            }
+                        }
+
+                        var npcVoiceManager = new NPCVoiceManager(voiceMappings, cacheTypes,
                             config.CacheFolder, "7fe29e49-2d45-423d-8efc-d8e2c1ceaf6d", false);
-                        _voiceEditor.NPCVoiceManager = _npcVoiceManager;
-                        _addonTalkManager = new AddonTalkManager(_framework, _clientState, condition, gameGui);
-                        _addonTalkHandler = new AddonTalkHandler(_addonTalkManager, _framework, _threadSafeObjectTable, clientState, this, chat, scanner, _redoLineWindow, _toast);
-                        _ipcSystem = new IpcSystem(pluginInterface, _addonTalkHandler, this);
+                        addonTalkManager = new AddonTalkManager(_framework, _clientState, condition, gameGui);
+                        addonTalkHandler = new AddonTalkHandler(addonTalkManager, _framework, _threadSafeObjectTable, clientState, this, chat, scanner, _redoLineWindow, _toast);
+                        ipcSystem = new IpcSystem(pluginInterface, addonTalkHandler, this);
+
+                        lock (_disposeLock)
+                        {
+                            // Async startup can complete after plugin unload has begun; avoid publishing new hook owners in that case.
+                            if (disposed)
+                            {
+                                ipcSystem.Dispose();
+                                addonTalkHandler.Dispose();
+                                return;
+                            }
+
+                            _npcVoiceManager = npcVoiceManager;
+                            _voiceEditor.NPCVoiceManager = _npcVoiceManager;
+                            _addonTalkHandler = addonTalkHandler;
+                            _addonTalkManager = addonTalkManager;
+                            _ipcSystem = ipcSystem;
+                            _gameGui = gameGui;
+                            _dragDrop = dragDrop;
+                            _videoWindow.WindowResized += _videoWindow_WindowResized;
+                            _toast.ErrorToast += _toast_ErrorToast;
+                        }
+
+                        addonTalkManager = null;
+                        addonTalkHandler = null;
+                        ipcSystem = null;
                         NpcVoiceManager.UseClosestRelay = config.UseClosestRelayServer;
-                        _gameGui = gameGui;
-                        _dragDrop = dragDrop;
-                        _videoWindow.WindowResized += _videoWindow_WindowResized;
-                        _toast.ErrorToast += _toast_ErrorToast;
                     }
                     catch (Exception e)
                     {
+                        ipcSystem?.Dispose();
+                        addonTalkHandler?.Dispose();
+                        if (addonTalkHandler == null)
+                        {
+                            addonTalkManager?.Dispose();
+                        }
+
                         Plugin.PluginLog?.Error(e, "[Artemis Roleplaying Kit] Async initialization failed: " + e.Message);
                     }
                 });
@@ -789,13 +832,16 @@ namespace RoleplayingVoice
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposed)
+            lock (_disposeLock)
             {
-                return;
-            }
+                if (disposed)
+                {
+                    return;
+                }
 
-            disposed = true;
-            Disposed = true;
+                disposed = true;
+                Disposed = true;
+            }
 
             RunDisposeStep("configuration save", () => config.Save());
             RunDisposeStep("configuration event", () => config.OnConfigurationChanged -= Config_OnConfigurationChanged);
@@ -821,6 +867,25 @@ namespace RoleplayingVoice
                 _clientState.Logout -= _clientState_Logout;
                 _clientState.TerritoryChanged -= _clientState_TerritoryChanged;
                 _clientState.LeavePvP -= _clientState_LeavePvP;
+                _clientState.CfPop -= _clientState_CfPop;
+            });
+            RunDisposeStep("window events", () =>
+            {
+                Window.RequestingReconnect -= Window_RequestingReconnect;
+                Window.OnMoveFailed -= Window_OnMoveFailed;
+                Window.OnWindowOperationFailed -= Window_OnWindowOperationFailed;
+                _videoWindow.WindowResized -= _videoWindow_WindowResized;
+            });
+            RunDisposeStep("Penumbra IPC events", () =>
+            {
+                if (!_penumbraEventSubscriptionsActive)
+                {
+                    return;
+                }
+
+                Penumbra.Api.IpcSubscribers.ModSettingChanged.Subscriber(pluginInterface).Event -= modSettingChanged;
+                Penumbra.Api.IpcSubscribers.GameObjectRedrawn.Subscriber(pluginInterface).Event -= gameObjectRedrawn;
+                _penumbraEventSubscriptionsActive = false;
             });
             RunDisposeStep("toast event", () => _toast.ErrorToast -= _toast_ErrorToast);
             RunDisposeStep("framework update event", () => _framework.Update -= framework_Update);

--- a/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
+++ b/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
@@ -1734,22 +1734,56 @@ namespace RoleplayingVoiceDalamud.Voice {
         }
 
         public void Dispose() {
-            framework.Update -= Framework_Update;
-            _chatGui.ChatMessage -= _chatGui_ChatMessage;
-            _clientState.TerritoryChanged -= _clientState_TerritoryChanged;
-            _toast.Toast -= _toast_Toast;
+            if (disposed) {
+                return;
+            }
+
             disposed = true;
 
-            _memoryService.Shutdown();
-            _settingService.Shutdown();
-            _gameDataService.Shutdown();
-            _actorService.Shutdown();
-            _gposeService.Shutdown();
-            _addressService.Shutdown();
-            _poseService?.Shutdown();
-            _targetService?.Shutdown();
-            _openChatBubbleHook?.Dispose();
-            addonTalkManager?.Dispose();
+            try {
+                // Dispose the hook before service teardown so a later cleanup failure cannot leak it during unload.
+                if (_openChatBubbleHook != null) {
+                    _openChatBubbleHook.Dispose();
+                    _openChatBubbleHook = null;
+                    Plugin.PluginLog?.Information("[Artemis Roleplaying Kit] Disposed OpenChatBubble hook.");
+                }
+            } catch (Exception e) {
+                Plugin.PluginLog?.Warning(e, "[Artemis Roleplaying Kit] OpenChatBubble hook cleanup failed: " + e.Message);
+            }
+
+            try {
+                framework.Update -= Framework_Update;
+                _chatGui.ChatMessage -= _chatGui_ChatMessage;
+                _clientState.TerritoryChanged -= _clientState_TerritoryChanged;
+                _toast.Toast -= _toast_Toast;
+            } catch (Exception e) {
+                Plugin.PluginLog?.Warning(e, "[Artemis Roleplaying Kit] AddonTalkHandler event cleanup failed: " + e.Message);
+            }
+
+            try {
+                // FFXIVHook installs a native keyboard hook, so unload must release it explicitly.
+                if (_hook != null) {
+                    _hook.Unhook();
+                    _hook = null;
+                    Plugin.PluginLog?.Information("[Artemis Roleplaying Kit] Disposed AddonTalkHandler keyboard hook.");
+                }
+            } catch (Exception e) {
+                Plugin.PluginLog?.Warning(e, "[Artemis Roleplaying Kit] AddonTalkHandler keyboard hook cleanup failed: " + e.Message);
+            }
+
+            try {
+                _memoryService.Shutdown();
+                _settingService.Shutdown();
+                _gameDataService.Shutdown();
+                _actorService.Shutdown();
+                _gposeService.Shutdown();
+                _addressService.Shutdown();
+                _poseService?.Shutdown();
+                _targetService?.Shutdown();
+                addonTalkManager?.Dispose();
+            } catch (Exception e) {
+                Plugin.PluginLog?.Warning(e, "[Artemis Roleplaying Kit] AddonTalkHandler service cleanup failed: " + e.Message);
+            }
         }
 
 

--- a/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
+++ b/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
@@ -1756,6 +1756,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                 _chatGui.ChatMessage -= _chatGui_ChatMessage;
                 _clientState.TerritoryChanged -= _clientState_TerritoryChanged;
                 _toast.Toast -= _toast_Toast;
+                _toast.QuestToast -= _toast_QuestToast;
             } catch (Exception e) {
                 Plugin.PluginLog?.Warning(e, "[Artemis Roleplaying Kit] AddonTalkHandler event cleanup failed: " + e.Message);
             }

--- a/ArtemisRoleplayingKit/Windows/PluginWindow.cs
+++ b/ArtemisRoleplayingKit/Windows/PluginWindow.cs
@@ -153,6 +153,17 @@ namespace RoleplayingVoice {
 
         }
 
+        public void DisposeHookResources() {
+            // The config window owns its keyboard helper hook; removing the window alone does not unhook it.
+            if (hook == null) {
+                return;
+            }
+
+            hook.Unhook();
+            hook = null;
+            Plugin.PluginLog?.Information("[Artemis Roleplaying Kit] Disposed plugin window keyboard hook.");
+        }
+
         private void VoiceEngineComboBox_OnSelectedIndexChanged(object sender, EventArgs e) {
             RefreshVoices();
         }


### PR DESCRIPTION
Intent: make plugin unload/reload safer by ensuring native hooks, IPC handlers, and long-lived event subscriptions are cleaned up reliably.

- Splits disposal into isolated cleanup steps so one failed teardown action does not prevent later hook/event cleanup.
- Disposes and nulls native hook owners during unload:
   - ActionEffectListener
   - EmoteReaderHooks
   - AddonTalkHandler OpenChatBubble hook
   - AddonTalkHandler keyboard hook
   - PluginWindow keyboard hook
   - sound filter hooks
- Stores the emote delegate instance so it can be unsubscribed correctly before disposing the emote hook.
- Adds missing event unsubscriptions for client state, window, toast, video resize, and optional Penumbra IPC events.
- Guards async startup against plugin disposal races so hook-owning resources are not published after unload has started.