### PR TITLE
A more complete fix for the non-english language false positives 

### DIFF
--- a/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
+++ b/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
@@ -91,15 +91,22 @@ namespace RoleplayingVoiceDalamud.Voice {
         bool _blockNpcChat = false;
         private List<NPCVoiceHistoryItem> _npcVoiceHistoryItems = new List<NPCVoiceHistoryItem>();
         private static readonly string[] StrongNonEnglishTextMarkers = new[] { "¿", "¡", "á", "é", "í", "ó", "ú", "ñ", "ü" };
-        
-        // Use word-boundaries for these weak markers to prevent matching inside English words.
+        // These markers are Spanish words/phrases that are specific enough to reject on
+        // their own when bounded as complete words. Accented words are intentionally
+        // omitted because StrongNonEnglishTextMarkers catches them first.
         private static readonly string[] WeakNonEnglishTextMarkers = new[] {
-            "Las", "Los", "Esta", "que", "haces", "tiene", "las", "los", "puente", "Heuso",
-            "Campamento", "Muéstrale", "evidencia", "un", "Busca", "frasco", "billis", "Sepulcro",
-            "sur", "cerca", "descubierto", "DESTINO", "y", "puede", "es", "muchas", "pero",
-            "asesino", "agua", "rota", "Por", "tu", "nombre", "porque", "mi", "querido",
-            "amigo", "caer", "en la", "Te", "esperaré", "Muy", "bien", "lugar", "termine",
-            "Y", "en lo", "de luto", "Si", "hecho", "usted", "nosotros", "también", "haremos"
+            "haces", "tiene", "puente", "Heuso", "Campamento", "evidencia", "Busca", "frasco",
+            "billis", "Sepulcro", "cerca", "descubierto", "DESTINO", "puede", "muchas", "pero",
+            "asesino", "agua", "rota.", "nombre", "porque", "querido", "amigo", "caer", "en la",
+            "lugar", "termine", "en lo", "de luto", "hecho", "usted", "nosotros", "haremos"
+        };
+        // Short Spanish function words are useful supporting evidence, but many can
+        // appear in English-client names, acronyms, or stylized text. Require multiple
+        // distinct hits so a single token like "si" does not suppress valid dialogue.
+        private const int RequiredGenericWeakNonEnglishMarkerMatches = 2;
+        private static readonly string[] GenericWeakNonEnglishTextMarkers = new[] {
+            "Las", "Los", "Esta", "que", "un", "sur", "y", "es", "Por", "tu", "mi", "Te",
+            "Muy", "bien", "Si"
         };
         private const int PauseOnlyDialogueAutoAdvanceDelayMs = 1500;
         private long _pauseOnlyDialogueSequence;
@@ -1738,15 +1745,55 @@ namespace RoleplayingVoiceDalamud.Voice {
             }
 
             foreach (string marker in WeakNonEnglishTextMarkers) {
-                // Use a word boundary (\b) so "Te" doesn't match inside "late".
-                // We use RegexOptions.IgnoreCase to make it case-insensitive.
-                if (System.Text.RegularExpressions.Regex.IsMatch(message, @"\b" + System.Text.RegularExpressions.Regex.Escape(marker) + @"\b", System.Text.RegularExpressions.RegexOptions.IgnoreCase)) {
+                if (ContainsWeakLanguageMarker(message, marker)) {
                     reason = $"contains weak non-English marker '{marker}'";
                     return false;
                 }
             }
 
+            var genericWeakMarkerHits = new List<string>();
+            foreach (string marker in GenericWeakNonEnglishTextMarkers) {
+                if (ContainsWeakLanguageMarker(message, marker)) {
+                    genericWeakMarkerHits.Add(marker);
+                    if (genericWeakMarkerHits.Count >= RequiredGenericWeakNonEnglishMarkerMatches) {
+                        reason = $"contains multiple generic weak non-English markers '{string.Join("', '", genericWeakMarkerHits)}'";
+                        return false;
+                    }
+                }
+            }
+
             return true;
+        }
+
+        private static bool ContainsWeakLanguageMarker(string message, string marker) {
+            int startIndex = 0;
+            while (startIndex < message.Length) {
+                int markerIndex = message.IndexOf(marker, startIndex, StringComparison.OrdinalIgnoreCase);
+                if (markerIndex == -1) {
+                    return false;
+                }
+
+                int markerEndIndex = markerIndex + marker.Length;
+                if (IsWeakMarkerBoundary(message, markerIndex - 1)
+                    && IsWeakMarkerBoundary(message, markerEndIndex)) {
+                    return true;
+                }
+
+                startIndex = markerIndex + 1;
+            }
+
+            return false;
+        }
+
+        private static bool IsWeakMarkerBoundary(string message, int index) {
+            if (index < 0 || index >= message.Length) {
+                return true;
+            }
+
+            char value = message[index];
+            // Treat common English-client name/stutter connectors as part of the
+            // word so single-letter markers do not reject text like Y'shtola or Y-You.
+            return !char.IsLetter(value) && value != '\'' && value != '\u2019' && value != '-';
         }
 
         private string FindNPCNameFromMessage(string message) {

--- a/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
+++ b/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
@@ -1429,8 +1429,12 @@ namespace RoleplayingVoiceDalamud.Voice {
                                     if (_plugin.Config.DebugMode) {
                                         _plugin.Chat.Print("Waveplayer is valid");
                                     }
-                                    Vector3 startingPosition = npcObject.Position;
-                                    if (npcObject != null && canDoLipSync) {
+                                    // Unknown/nameless dialogue can still be voiced by falling back to
+                                    // the local player as the audio source. Only read NPC position data
+                                    // after DiscoverNpc() has actually resolved a game object for lip sync.
+                                    bool canTrackNpcLipSync = npcObject != null && canDoLipSync;
+                                    Vector3 startingPosition = canTrackNpcLipSync ? npcObject.Position : Vector3.Zero;
+                                    if (canTrackNpcLipSync) {
                                         actorMemory = new ActorMemory();
                                         try {
                                             actorMemory.SetAddress(npcObject.Address);
@@ -1480,7 +1484,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                                             if (_hook != null) {
                                                 try {
                                                     if (animationMemory != null) {
-                                                        if (npcObject != null && canDoLipSync) {
+                                                        if (canTrackNpcLipSync) {
                                                             animationMemory.LipsOverride = 0;
                                                             if (!Conditions.Instance()->BoundByDuty || IsInACutscene()) {
                                                                 if (IsInACutscene()) {
@@ -1514,7 +1518,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                                             }
                                         }, delegate (object sender, StreamVolumeEventArgs e) {
                                             if (animationMemory != null) {
-                                                if (npcObject != null && canDoLipSync) {
+                                                if (canTrackNpcLipSync) {
                                                     if (e.MaxSampleValues.Length > 0) {
                                                         if (_plugin.Config.DebugMode && IsInACutscene()) {
                                                             Plugin.PluginLog.Debug($"[LipSync] Vol: {e.MaxSampleValues[0]:F3} State: {(_state != null)} Dist: {Vector3.Distance(startingPosition, npcObject.Position):F2}");


### PR DESCRIPTION
Intent: reduce false positives in the non-English dialogue filter while keeping the detection logic readable and easy to tune.

Changes:

- Matches weak non-English markers as bounded words/phrases instead of raw substring matches.
- Avoids regex by using an explicit boundary helper for easier review and troubleshooting.
- Treats apostrophes and hyphens as word connectors, so names/stutters like Y'shtola, Y’all, and Y-You do not trip the standalone y marker.
- Splits Spanish weak markers into:
  - specific words/phrases that can reject by themselves
  - generic short/function words that require multiple distinct hits
- Removes redundant case variants and accented weak markers already covered by the strong accented-character check.
- Keeps rejection logging descriptive by reporting whether the text matched a strong marker, specific weak marker, or multiple generic weak markers.

Validation:
- Spot checks confirmed bundled nameless.json dialogue is no longer rejected by these weak markers.
