### PR TITLE
Fix Post-Cutscene TTS Block Reset

### DIFF
--- a/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
+++ b/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
@@ -1423,6 +1423,8 @@ namespace RoleplayingVoiceDalamud.Voice {
                                             }, _plugin.Config.NPCSpeechSpeed, values.Item2 == "Elevenlabs" ? 0.5f : (values.Item2 == "XTTS" ? 1.8f : 1.8f));
                                         } else {
                                             TraceNpcTts($"Audio ready but playback suppressed by blockAudioGeneration sequence={request.Sequence} npc='{nameToUse}' text='{PreviewText(value)}'");
+                                            // A cutscene SCD can arrive while a relay request is in flight.
+                                            // Once that late response is suppressed, the block has done its job.
                                             ClearConsumedAudioGenerationBlock("npc audio playback suppressed");
                                         }
                                     }

--- a/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
+++ b/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
@@ -602,7 +602,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                                                     if (_currentDialoguePaths.Count > 0) {
                                                         _currentDialoguePaths[_currentDialoguePaths.ElementAt(_currentDialoguePaths.Count - 1).Key] = true;
                                                     }
-                                                    _blockAudioGeneration = false;
+                                                    ClearConsumedAudioGenerationBlock("talk state handled");
                                                 }
                                             } else if (stateSnapshot != null) {
                                                 TraceNpcTtsDebug($"Ignored talk state speaker='{stateSnapshot.Speaker}' textPresent={!string.IsNullOrEmpty(stateSnapshot.Text)} text='{PreviewText(stateSnapshot.Text)}'");
@@ -715,6 +715,18 @@ namespace RoleplayingVoiceDalamud.Voice {
                 _state != null && _currentText == pauseText && IsPauseOnlyDialogue(_state.Text)) {
                 _hook?.SendAsyncKey(Keys.NumPad0);
             }
+        }
+
+        private void ClearConsumedAudioGenerationBlock(string reason) {
+            if (!_blockAudioGeneration) {
+                return;
+            }
+
+            // Cutscene audio blocks are intended to suppress one matching NPC line.
+            // Clear the flag once that block has been consumed so it cannot leak into
+            // later manually advanced dialogue after the voiced scene has ended.
+            _blockAudioGeneration = false;
+            TraceNpcTts($"Cleared consumed cutscene audio block reason='{reason}' blockCount={_blockAudioGenerationCount}");
         }
 
         private bool ShouldSkipNpcText(string npcName, string message) {
@@ -1411,6 +1423,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                                             }, _plugin.Config.NPCSpeechSpeed, values.Item2 == "Elevenlabs" ? 0.5f : (values.Item2 == "XTTS" ? 1.8f : 1.8f));
                                         } else {
                                             TraceNpcTts($"Audio ready but playback suppressed by blockAudioGeneration sequence={request.Sequence} npc='{nameToUse}' text='{PreviewText(value)}'");
+                                            ClearConsumedAudioGenerationBlock("npc audio playback suppressed");
                                         }
                                     }
                                     break;


### PR DESCRIPTION
Intent: prevent a skipped/consumed cutscene audio block from suppressing later NPC TTS after the voiced scene has moved on.

Changes:

- Adds ClearConsumedAudioGenerationBlock(...) to centralize clearing _blockAudioGeneration.
- Also clears the block when generated NPC audio is ready but playback is suppressed because a cutscene SCD arrived while the relay request was still in flight.
- Keeps logging at the existing [NPC TTS] boundary level so validation can watch for the clear event without adding per-frame noise.