### PR TITLE
Fix Overlapping TTS Playback when different characters are speaking in turns

### DIFF
--- a/ArtemisRoleplayingKit/CoreLogic/ConfigurationSetup.cs
+++ b/ArtemisRoleplayingKit/CoreLogic/ConfigurationSetup.cs
@@ -45,10 +45,12 @@ namespace RoleplayingVoice {
                     _playerCamera = new MediaCameraObject(_camera);
                     if (_mediaManager != null) {
                         _mediaManager.OnErrorReceived -= _mediaManager_OnErrorReceived;
+                        _mediaManager.OnDiagnosticReceived -= _mediaManager_OnDiagnosticReceived;
                     }
                     _mediaManager = new MediaManager(_playerObject, _playerCamera, Path.GetDirectoryName(pluginInterface.AssemblyLocation.FullName));
                     _voiceEditor.MediaManager = _mediaManager;
                     _mediaManager.OnErrorReceived += _mediaManager_OnErrorReceived;
+                    _mediaManager.OnDiagnosticReceived += _mediaManager_OnDiagnosticReceived;
                     _videoWindow.MediaManager = _mediaManager;
                 }
                 if (_speechToTextManager == null || forceNewAssignments) {

--- a/ArtemisRoleplayingKit/Plugin.cs
+++ b/ArtemisRoleplayingKit/Plugin.cs
@@ -764,6 +764,10 @@ namespace RoleplayingVoice
         {
             Plugin.PluginLog?.Warning(e.Exception, e.Exception.Message);
         }
+        private void _mediaManager_OnDiagnosticReceived(object sender, string e)
+        {
+            Plugin.PluginLog?.Information("[NPC TTS] " + e);
+        }
         #endregion
         #region IDisposable Support
         private void RunDisposeStep(string cleanupName, System.Action cleanup)
@@ -877,6 +881,7 @@ namespace RoleplayingVoice
                 {
                     _mediaManager.Invalidated = true;
                     _mediaManager.OnErrorReceived -= _mediaManager_OnErrorReceived;
+                    _mediaManager.OnDiagnosticReceived -= _mediaManager_OnDiagnosticReceived;
                     _mediaManager.Dispose();
                     _mediaManager = null;
                 }

--- a/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
+++ b/ArtemisRoleplayingKit/Voice/AddonTalkHandler.cs
@@ -710,6 +710,7 @@ namespace RoleplayingVoiceDalamud.Voice {
                                                 if (stateSnapshot.Text != _currentText) {
                                                     _lastText = _currentText;
                                                     CancelNpcVoiceRequests("talk state text changed");
+                                                    StopCurrentNpcSpeechBeforeReplacement("talk state text changed");
                                                     _currentText = stateSnapshot.Text;
                                                     _lastKnownSpeaker = stateSnapshot.Speaker;
                                                     _redoLineWindow.IsOpen = false;
@@ -1037,6 +1038,21 @@ namespace RoleplayingVoiceDalamud.Voice {
                 _npcVoiceRequestSequence++;
                 TraceNpcTts($"Cancelled pending requests; new sequence={_npcVoiceRequestSequence} reason='{reason}'");
             }
+        }
+
+        private void StopCurrentNpcSpeechBeforeReplacement(string reason) {
+            var speechObject = _currentSpeechObject;
+            if (speechObject == null) {
+                return;
+            }
+
+            // A new talk line can arrive before the addon reports that the old
+            // line has cleared. Stop the outgoing speech object before NPCText()
+            // overwrites _currentSpeechObject with the next speaker, otherwise
+            // skipping from one NPC to another can leave the first line playing.
+            _currentSpeechObject = null;
+            TraceNpcTts($"Stopping active dialogue audio before replacement reason='{reason}'");
+            _plugin.MediaManager.StopAudio(speechObject);
         }
 
         private bool IsCurrentNpcVoiceRequest(long sequence) {


### PR DESCRIPTION
Intent: stop outgoing NPC dialogue audio when the talk line changes, especially when skipping from one speaker to another.

- Stops the active NPC speech object before _currentSpeechObject is replaced by the next speaker.
- Keeps existing request cancellation behavior so stale relay responses cannot play after dialogue advances.
- Wires Core media diagnostics into the plugin log under the existing [NPC TTS] logging style.
- Adds maintainer comments around the turn-swap stop path to explain why stop must happen before replacement.

Depends on : https://github.com/Sebane1/RoleplayingVoiceCore/pull/8 